### PR TITLE
Events pages

### DIFF
--- a/docs/typelibrary/events/ARTimeOut.md
+++ b/docs/typelibrary/events/ARTimeOut.md
@@ -1,3 +1,64 @@
-### ARTimeOut
+# ARTimeOut
 
 ![ARTimeOut](https://user-images.githubusercontent.com/116869307/214142115-28b88284-c3b6-4c78-9145-6de372738f36.png)
+
+* * * * * * * * * *  
+
+## Einleitung  
+
+Die IEC 61499 ist ein internationaler Standard für die Modellierung verteilter industrieller Steuerungssysteme. Innerhalb dieses Standards sind Adaptertypen eine wichtige Komponente, um wiederverwendbare Schnittstellen zwischen Funktionsbausteinen zu definieren. Der **ARTimeOut**-Adapter (Adapter for Resettable Timeout) ist ein Beispiel für einen solchen Adapter, der eine Schnittstelle für einen rücksetzbaren Timeout-Service bereitstellt. 
+
+## Struktur des ARTimeOut-Adapters  
+
+Der ARTimeOut-Adapter ist als **AdapterType** in der IEC 61499 spezifiziert und definiert eine Schnittstelle für die Kommunikation zwischen einem SOCKET und einem PLUG.  
+
+### Schnittstelle (Interface)  
+
+Die Schnittstelle des ARTimeOut-Adapters besteht aus:  
+
+- **Eingangsereignisse (Event Inputs)**:  
+  - **TimeOut**: Dieses Ereignis wird vom SOCKET ausgelöst, um anzuzeigen, dass der Timeout abgelaufen ist.  
+
+- **Ausgangsereignisse (Event Outputs)**:  
+  - **START**: Dieses Ereignis wird vom PLUG ausgelöst, um den Timeout zu starten oder zurückzusetzen. Es ist mit der Ausgangsvariablen **DT** verknüpft, die die Timeout-Dauer definiert.  
+  - **STOP**: Dieses Ereignis wird vom PLUG ausgelöst, um den Timeout anzuhalten.  
+
+- **Ausgangsvariable (Output Variable)**:  
+  - **DT (Duration Time)**: Eine Zeitvariable (TIME), die die Dauer des Timeouts angibt.  
+
+### Service-Verhalten  
+
+Der ARTimeOut-Adapter bietet zwei Service-Sequenzen:  
+
+1. **Timeout**:  
+   - Der PLUG sendet ein **START**-Ereignis mit der Zeitdauer **DT**, um den Timeout zu starten.  
+   - Wenn der Timeout abläuft, sendet der SOCKET ein **TimeOut**-Ereignis zurück an den PLUG.  
+
+2. **NormalOperation**:  
+   - Der PLUG sendet ein **START**-Ereignis mit der Zeitdauer **DT**, um den Timeout zu starten.  
+   - Der PLUG kann ein **STOP**-Ereignis senden, um den Timeout vorzeitig zu beenden.  
+
+## Verhalten des ARTimeOut-Adapters  
+
+Der ARTimeOut-Adapter ermöglicht die Steuerung eines Timeout-Mechanismus mit folgenden Funktionen:  
+
+1. **Start/Reset des Timeouts**:  
+   - Durch das **START**-Ereignis wird der Timeout mit der angegebenen Dauer **DT** gestartet oder zurückgesetzt.  
+
+2. **Stop des Timeouts**:  
+   - Das **STOP**-Ereignis beendet den Timeout vorzeitig.  
+
+3. **Timeout-Ablauf**:  
+   - Wenn der Timeout abläuft, wird das **TimeOut**-Ereignis ausgelöst, um den PLUG zu benachrichtigen.  
+
+## Anwendungsbeispiele  
+
+Der ARTimeOut-Adapter kann in verschiedenen industriellen Steuerungsanwendungen eingesetzt werden, insbesondere in Szenarien, in denen ein zuverlässiger und rücksetzbarer Timeout-Mechanismus erforderlich ist. Beispiele sind:  
+
+- **Netzwerkkommunikation**: Überwachung von Antwortzeitüberschreitungen in verteilten Systemen.  
+- **Maschinensteuerung**: Timeout für die Ausführung von Befehlen, um hängende Prozesse zu erkennen.  
+- **Sicherheitssysteme**: Überwachung von Sensoren, um Fehlfunktionen zu erkennen, wenn keine Aktualisierungen erfolgen.  
+
+## Fazit  
+
+Der ARTimeOut-Adapter ist ein nützliches Werkzeug in der IEC 61499, um eine standardisierte Schnittstelle für rücksetzbare Timeout-Services bereitzustellen. Durch seine klare Trennung zwischen SOCKET und PLUG sowie die definierten Service-Sequenzen eignet er sich ideal für die Integration in verteilte Steuerungssysteme. Die Fähigkeit, den Timeout zu starten, zu stoppen und bei Ablauf zu benachrichtigen, macht ihn zu einer flexiblen Lösung für eine Vielzahl von industriellen Anwendungen.  

--- a/docs/typelibrary/events/ATimeOut.md
+++ b/docs/typelibrary/events/ATimeOut.md
@@ -1,3 +1,62 @@
-### ATimeOut
+# ATimeOut
 
 ![ATimeOut](https://user-images.githubusercontent.com/116869307/214142228-09857ba5-6164-4597-bb66-8a99e74f4d14.png)
+
+* * * * * * * * * *  
+
+## Einleitung  
+Die IEC 61499 ist ein internationaler Standard für die Modellierung verteilter industrieller Steuerungssysteme. Der **ATimeOut**-Baustein (Active Timeout) ist ein Funktionsbaustein, der einen aktiven Timeout-Mechanismus bereitstellt. Dieser Aufsatz beschreibt die Struktur, das Verhalten und die typischen Anwendungen des ATimeOut-Bausteins.  
+
+## Struktur des ATimeOut-Bausteins  
+Der ATimeOut-Baustein ist als **Basic Function Block (BFB)** oder **Composite Function Block (CFB)** in der IEC 61499 spezifiziert.  
+
+### Schnittstelle (Interface)  
+Die typische Schnittstelle des ATimeOut-Bausteins umfasst:  
+
+- **Eingangsereignisse (Event Inputs)**:  
+  - **START**: Löst den Timeout mit der konfigurierten Dauer aus.  
+  - **STOP**: Bricht den laufenden Timeout ab.  
+  - **RESET**: Setzt den Timeout zurück.  
+
+- **Ausgangsereignisse (Event Outputs)**:  
+  - **TimeOut**: Wird ausgelöst, wenn der Timeout abgelaufen ist.  
+
+- **Eingangsvariablen (Input Variables)**:  
+  - **PT (Preset Time)**: Die vordefinierte Timeout-Dauer (TIME-Datentyp).  
+
+- **Ausgangsvariablen (Output Variables)**:  
+  - **Q**: Boolescher Ausgang, der den aktiven Timeout-Zustand anzeigt (TRUE = Timeout läuft).  
+
+## Verhalten des ATimeOut-Bausteins  
+1. **Start des Timeouts**:  
+   - Bei Empfang des **START**-Ereignisses beginnt der Timeout mit der in **PT** definierten Dauer.  
+   - Der Ausgang **Q** wird auf TRUE gesetzt.  
+
+2. **Abbruch des Timeouts**:  
+   - Ein **STOP**-Ereignis setzt **Q** auf FALSE und hält den Timeout an.  
+
+3. **Timeout-Ablauf**:  
+   - Nach Ablauf von **PT** wird das **TimeOut**-Ereignis ausgelöst und **Q** auf FALSE gesetzt.  
+
+4. **Reset**:  
+   - Das **RESET**-Ereignis setzt den internen Timer zurück.  
+
+## Technische Besonderheiten  
+- Der Baustein kann sowohl in zyklischen als auch ereignisgesteuerten Systemen eingesetzt werden.  
+- Die Timeout-Logik ist unabhängig von der Zykluszeit des übergeordneten Systems.  
+
+## Anwendungsbeispiele  
+- **Überwachung von Kommunikationszeitüberschreitungen** in verteilten Steuerungssystemen  
+- **Maschinensicherheit**: Erkennung von Stillstandszeiten oder fehlenden Sensorupdates  
+- **Prozesssteuerung**: Timeout für kritische Operationen  
+
+## Vergleich mit ähnlichen Bausteinen  
+| Feature        | ATimeOut | ARTimeOut (Adapter) | E_PULSE |  
+|----------------|----------|---------------------|---------|  
+| Timeout-Trigger| START    | START               | REQ     |  
+| Abbruch        | STOP     | STOP                | R (Reset)|  
+| Rückmeldung    | TimeOut  | TimeOut             | CNF     |  
+| Typ           | FB       | Adapter             | FB      |  
+
+## Fazit  
+Der ATimeOut-Baustein bietet eine robuste Lösung für Timeout-Mechanismen in IEC 61499-Systemen. Durch seine klare Schnittstelle und flexible Einsatzmöglichkeiten eignet er sich besonders für Sicherheits- und Überwachungsfunktionen in industriellen Steuerungen. Die Unabhängigkeit von der Zykluszeit macht ihn zudem für ereignisgesteuerte Architekturen interessant.

--- a/docs/typelibrary/events/E_CTD.md
+++ b/docs/typelibrary/events/E_CTD.md
@@ -1,26 +1,59 @@
-### E\_CTD
+# E\_CTD
 
-Event-Driven Down Counter
+![E_CTD Diagram](https://user-images.githubusercontent.com/113907528/204893284-f9e75568-aeeb-4000-b4eb-2b0a7ef18187.png)  
 
-![](https://user-images.githubusercontent.com/113907528/204893284-f9e75568-aeeb-4000-b4eb-2b0a7ef18187.png)
+* * * * * * * * * *  
 
-*   Input
-    *   CD Count Down
-    *   LD Load counter value
-*   Output
-    *   CDO Count Down Output Event 
-    *   LDO Reset Output Event
+## Einleitung  
+Der **E_CTD** (Event-Driven Down Counter) ist ein ereignisgesteuerter Abwärtszähler nach dem IEC 61499-Standard. Dieser Funktionsbaustein wird in industriellen Steuerungssystemen eingesetzt, um Zählvorgänge zu realisieren, die durch Ereignisse gesteuert werden.  
 
-Input:
+## Struktur des E_CTD-Bausteins  
 
-CD:  Count Down Ereignis zum Abwärtszählen
+### Schnittstelle (Interface)  
 
-LD: Zählwert wird geladen
+**Eingangsereignisse (Event Inputs):**  
+- **CD (Count Down):** Dekrementiert den Zählerstand um 1.  
+- **LD (Load):** Lädt einen neuen Startwert in den Zähler.  
 
-Output:
+**Ausgangsereignisse (Event Outputs):**  
+- **CDO (Count Down Output):** Wird ausgelöst, wenn der Zählerstand 0 erreicht.  
+- **LDO (Load Output):** Bestätigt das erfolgreiche Laden eines neuen Zählerwerts.  
 
-CDO: Countdown Ausgangsereignis
+**Eingangsvariablen (Input Variables):**  
+- **PV (Preset Value):** Der Startwert, der bei einem LD-Ereignis geladen wird (Datentyp: INT).  
 
-LDO: Ausgansereignis zurücksetzen
+**Ausgangsvariablen (Output Variables):**  
+- **CV (Current Value):** Der aktuelle Zählerstand (Datentyp: INT).  
 
-![](https://user-images.githubusercontent.com/113907474/227978396-fc4435d7-725a-4e9c-ba15-64cf12477f9f.png)
+## Verhalten des E_CTD-Bausteins  
+
+1. **Initialisierung:**  
+   - Der Zähler wird mit dem Wert **PV** initialisiert, wenn ein **LD**-Ereignis eintritt.  
+   - Das **LDO**-Ereignis wird ausgelöst, um das erfolgreiche Laden zu bestätigen.  
+
+2. **Abwärtszählen:**  
+   - Bei jedem **CD**-Ereignis wird der Zählerstand **CV** um 1 verringert.  
+   - Wenn **CV** den Wert 0 erreicht, wird das **CDO**-Ereignis ausgelöst.  
+
+3. **Neuladen des Zählers:**  
+   - Ein erneutes **LD**-Ereignis setzt **CV** zurück auf **PV** und löst **LDO** aus.  
+
+## Technische Besonderheiten  
+- **Ereignisgesteuert:** Der Baustein arbeitet ausschließlich auf Basis von Ereignissen und benötigt keinen zyklischen Aufruf.  
+- **Flexible Initialisierung:** Der Startwert **PV** kann jederzeit durch ein **LD**-Ereignis geändert werden.  
+
+## Anwendungsbeispiele  
+- **Produktionslinien:** Zählen von produzierten Einheiten.  
+- **Verpackungsmaschinen:** Steuerung von Füllvorgängen.  
+- **Energiemanagement:** Überwachung von Verbrauchszyklen.  
+
+## Vergleich mit ähnlichen Bausteinen  
+
+| Feature          | E_CTD             | E_CTU (Up Counter) | E_CTUD (Up/Down Counter) |  
+|------------------|-------------------|--------------------|--------------------------|  
+| Zählrichtung     | Abwärts           | Aufwärts           | Beides                   |  
+| Ereignisgesteuert| Ja                | Ja                 | Ja                       |  
+| Reset-Funktion   | LD (Neuladen)     | R (Reset)          | R (Reset)                |  
+
+## Fazit  
+Der **E_CTD**-Baustein ist ein wesentliches Element in der IEC 61499, das eine zuverlässige und flexible Zählfunktion für industrielle Steuerungen bietet. Seine ereignisgesteuerte Natur macht ihn besonders geeignet für verteilte Systeme, wo zyklische Abfragen nicht praktikabel sind. Durch die klare Schnittstelle und das intuitive Verhalten ist er einfach in bestehende Steuerungskonzepte zu integrieren.

--- a/docs/typelibrary/events/E_CTUD.md
+++ b/docs/typelibrary/events/E_CTUD.md
@@ -1,23 +1,74 @@
-### E\_CTUD
+# E_CTUD
 
-Event-Driven Up-Down Counter
+![E_CTUD Diagram](https://user-images.githubusercontent.com/113907528/204895474-3f88876a-7ce5-406e-8f44-765c1b97226c.png)
 
-Der Funktionsblock E\_CTUD (Counter Up/Down) ist ein wichtiger Bestandteil der IEC 61499 Norm und wird häufig in Steuerungssystemen verwendet. Er dient dazu, Zählerwerte zu erhöhen oder zu verringern und kann in vielen verschiedenen Anwendungen eingesetzt werden.
+* * * * * * * * * *
 
-Der E\_CTUD Funktionsblock besteht aus mehreren Eingängen und Ausgängen, die für die Steuerung und Überwachung des Zählerwerts verwendet werden. Der wichtigste Eingang ist der "CU" Eingang, der verwendet wird, um den Zählerwert zu erhöhen oder zu verringern. Der "RESET" Eingang dient zum Zurücksetzen des Zählerwerts auf null, während der "LOAD" Eingang verwendet wird, um den Zählerwert auf einen festgelegten Wert zu laden.
+## Einleitung
+Der **E_CTUD** (Event-Driven Up-Down Counter) ist ein zentraler Funktionsbaustein der IEC 61499 Norm für industrielle Steuerungssysteme. Als bidirektionaler Zähler ermöglicht er sowohl Aufwärts- als auch Abwärtszählungen und bietet damit vielfältige Einsatzmöglichkeiten in Automatisierungslösungen.
 
-Der E\_CTUD Funktionsblock hat auch mehrere Ausgänge, die für die Überwachung des Zählerwerts und die Steuerung von Prozessen verwendet werden.
+## Schnittstellenstruktur
 
-![](https://user-images.githubusercontent.com/113907528/204895474-3f88876a-7ce5-406e-8f44-765c1b97226c.png)
+### **Ereignis-Eingänge**
+- `CU` (Count Up): Erhöht den Zählerstand
+- `CD` (Count Down): Verringert den Zählerstand
+- `R` (Reset): Setzt den Zähler zurück
+- `LD` (Load): Lädt einen vordefinierten Wert
 
-*   Input
-    *   CU Count Up 
-    *   CD Count Down
-    *   R Reset
-    *   LD Load
-    *   PV Preset Value
-*   Output
-    *   CO Count Output Event
-    *   RO Reset Output Event
-    *   QU CV   >= PV
-    *   QD CV  \<= 0
+### **Ereignis-Ausgänge**
+- `CO` (Count Output): Signalisiert Zähleraktivität
+- `RO` (Reset Output): Bestätigt Reset-Vorgang
+
+### **Daten-Ein-/Ausgänge**
+| Port | Typ | Beschreibung |
+|------|-----|-------------|
+| PV   | INT | Preset Value (Vorgabewert) |
+| CV   | INT | Current Value (aktueller Zählerstand) |
+| QU   | BOOL | True wenn CV ≥ PV |
+| QD   | BOOL | True wenn CV ≤ 0 |
+
+## Funktionsweise
+
+1. **Zähloperationen**
+   - `CU`-Ereignis: Inkrementiert CV um 1
+   - `CD`-Ereignis: Dekrementiert CV um 1
+
+2. **Steuerfunktionen**
+   - `R`-Ereignis: Setzt CV auf 0 (löst RO aus)
+   - `LD`-Ereignis: Lädt PV in CV
+
+3. **Statusüberwachung**
+   - QU wird aktiv bei CV ≥ PV
+   - QD wird aktiv bei CV ≤ 0
+
+## Technische Besonderheiten
+
+✔ **Bidirektionale Zählung** (Auf- und Abwärts)
+✔ **Flexible Wertvorgabe** via PV
+✔ **Echtzeit-Statusüberwachung** (QU/QD)
+✔ **Ereignisgesteuerte Architektur**
+
+## Anwendungsszenarien
+
+- **Produktionszählung**: Teilezählung in beiden Richtungen
+- **Lagerverwaltung**: Ein- und Ausgangskontrolle
+- **Prozesssteuerung**: Zyklische Operationen
+
+## Vergleich mit ähnlichen Bausteinen
+
+| Feature | E_CTUD | E_CTU | E_CTD |
+|---------|--------|-------|-------|
+| Richtung | Auf/Ab | Auf | Ab |
+| Reset | R | R | - |
+| Load | LD | - | LD |
+| Status | QU/QD | Q | Q |
+
+## Fazit
+
+Der E_CTUD-Baustein stellt eine leistungsfähige Zähllösung für industrielle Steuerungen dar, die durch seine bidirektionale Funktionalität und flexible Steuerbarkeit besticht. Besondere Stärken sind:
+
+- Komplette Ereignissteuerung
+- Sofortige Statusrückmeldung
+- Einfache Integration in IEC 61499-Systeme
+
+Durch die Kombination aus Zählfunktion und Statusüberwachung eignet er sich ideal für komplexe Steuerungsaufgaben in automatisierten Produktionsumgebungen. Die strikte Einhaltung der IEC 61499-Standards gewährleistet zudem problemlose Interoperabilität mit anderen Funktionsbausteinen.

--- a/docs/typelibrary/events/E_CTUD_UDINT.md
+++ b/docs/typelibrary/events/E_CTUD_UDINT.md
@@ -1,9 +1,85 @@
-### E_CTUD_UDINT
+# E_CTUD_UDINT  
 
+![E_CTUD_UDINT](https://user-images.githubusercontent.com/116869307/214142444-55a16971-caf0-4c6c-a1fa-c0294a26464a.png)  
 
-![E_CTUD_UDINT](https://user-images.githubusercontent.com/116869307/214142444-55a16971-caf0-4c6c-a1fa-c0294a26464a.png)
+* * * * * * * * * *   
 
+## Einleitung  
+Der **E_CTUD_UDINT** ist ein erweiterter Zählbaustein nach IEC 61499, der sowohl Aufwärts- als auch Abwärtszählfunktionen mit dem Datentyp UDINT (unsigned double integer) unterstützt. Dieser Baustein kombiniert die Funktionalität eines hochpräzisen Zählers mit der Flexibilität ereignisgesteuerter Operationen.
 
+---
+
+## Schnittstellenstruktur  
+
+### **Ereignis-Eingänge**  
+- `CU` (Count Up): Erhöht den Zählerstand um 1  
+- `CD` (Count Down): Verringert den Zählerstand um 1  
+- `R` (Reset): Setzt den Zähler auf 0 zurück  
+- `LD` (Load): Lädt einen neuen vordefinierten Wert  
+
+### **Ereignis-Ausgänge**  
+- `CUO` (Count Up Overflow): Wird bei Überlauf ausgelöst  
+- `CDO` (Count Down Underflow): Wird bei Unterlauf ausgelöst  
+- `LDO` (Load Done): Bestätigt erfolgreiches Laden  
+
+### **Daten-Ein-/Ausgänge**  
+| Port | Typ   | Beschreibung                     |  
+|------|-------|----------------------------------|  
+| PV   | UDINT | Vorgabewert (Preset Value)       |  
+| CV   | UDINT | Aktueller Zählerstand (Current Value) |  
+
+---
+
+## Funktionsweise  
+
+1. **Zähloperationen**  
+   - Bei jedem `CU`-Ereignis: `CV = CV + 1`  
+   - Bei jedem `CD`-Ereignis: `CV = CV - 1`  
+
+2. **Spezialfälle**  
+   - **Überlauf**: Bei Erreichen von UDINT-Maximum → `CUO`  
+   - **Unterlauf**: Bei Unterschreiten von 0 → `CDO`  
+
+3. **Steuerfunktionen**  
+   - `R` setzt `CV` sofort auf 0  
+   - `LD` lädt `PV` in `CV` und triggert `LDO`  
+
+---
+
+## Technische Besonderheiten  
+
+✔ **32-bit Unsigned Integer** (0 bis 4,294,967,295)  
+✔ **Ereignisgesteuerte Logik** (kein zyklischer Aufruf nötig)  
+✔ **Parallele Operationsmöglichkeit** (gleichzeitige CU/CD-Events)  
+
+---
+
+## Anwendungsszenarien  
+
+- **Produktionsüberwachung**: Präzise Teilezählung  
+- **Energiemanagement**: Verbrauchszählung  
+- **Prozesssteuerung**: Zyklusüberwachung  
+
+---
+
+## Vergleich mit ähnlichen Bausteinen  
+
+| Feature        | E_CTUD_UDINT | E_CTU | E_CTD |  
+|---------------|-------------|-------|-------|  
+| Zählrichtung  | Auf/Ab      | Auf   | Ab    |  
+| Datentyp      | UDINT       | INT   | INT   |  
+| Überlaufkontrolle | Ja      | Nein  | Nein  |  
+
+---
+
+## Fazit  
+
+Der E_CTUD_UDINT-Baustein bietet industriellen Steuerungssystemen eine leistungsstarke Zähllösung mit:  
+- Erweiterter Zahlenreichweite (32-bit)  
+- Bidirektionaler Zählfunktion  
+- Robuster Ereignissteuerung  
+
+Durch seine präzise Steuerlogik und große Zählkapazität eignet er sich besonders für Hochleistungsanwendungen in automatisierten Produktionsumgebungen. Die strikte Ereignisorientierung macht ihn zudem ideal für verteilte Steuerungsarchitekturen nach IEC 61499.
 
 
 

--- a/docs/typelibrary/events/E_CYCLE.md
+++ b/docs/typelibrary/events/E_CYCLE.md
@@ -1,17 +1,68 @@
-### E\_CYCLE Taktgenerator (Blinker)
+# E_CYCLE
 
-![](https://user-images.githubusercontent.com/113907471/204306660-9e93e9cc-10f0-4d51-829f-229ee64a1227.png)
+![E_CYCLE Diagram](https://user-images.githubusercontent.com/113907471/204306660-9e93e9cc-10f0-4d51-829f-229ee64a1227.png)
 
-Zeitschaltrelai zb. Blinker 
+* * * * * * * * * *
 
-Start= Event vom Schalter zum Starten 
+## Einleitung
+Der **E_CYCLE** ist ein taktgebender Funktionsbaustein nach IEC 61499, der zyklische Ereignisse mit einstellbarer Dauer generiert. Hauptsächlich als Blinker oder Zeitschaltrelais eingesetzt, ermöglicht er die Steuerung periodischer Prozesse in industriellen Automatisierungssystemen.
 
-Stop= Event vom Schalter zum Ausschalten 
+## Schnittstellenstruktur
 
-Cycle Tyme= Einstellen der Länge des Events (Ausgang wird so lange bestromt)
+### **Ereignis-Eingänge**
+- `START`: Aktiviert den Taktgenerator
+- `STOP`: Deaktiviert den Taktgenerator
 
-EQ= Ausgang des Events
+### **Ereignis-Ausgänge**
+- `EO` (Event Output): Zyklisches Ausgangssignal
 
-Nur beim Joisick !!!
+### **Daten-Eingänge**
+| Port | Typ | Beschreibung |
+|------|-----|-------------|
+| DT   | TIME | Zykluszeit (Ein-/Ausschaltdauer) |
 
-![](https://user-images.githubusercontent.com/113907471/204314547-ca49268f-d83b-423e-8734-a2fca27e4e9a.png)
+## Funktionsweise
+
+1. **Startphase**
+   - Bei `START`-Ereignis beginnt der Zyklus
+   - Ausgang `EO` wird aktiviert
+
+2. **Zyklusbetrieb**
+   - Nach Ablauf von `DT` wechselt der Ausgangszustand
+   - Dieser Wechsel wiederholt sich kontinuierlich
+
+3. **Stoppphase**
+   - `STOP`-Ereignis beendet den Zyklus
+   - Ausgang `EO` wird deaktiviert
+
+## Technische Besonderheiten
+
+✔ **Präzise Zeitsteuerung** (millisekundengenaue Zykluszeiten)
+✔ **Ereignisgesteuerte Steuerung** (kein Polling erforderlich)
+✔ **Echtzeitfähig** für industrielle Anwendungen
+✔ **Einfache Konfiguration** durch TIME-Parameter
+
+## Anwendungsszenarien
+
+- **Warnblinkanlagen**: Periodische Signalisierung
+- **Maschinensteuerung**: Zyklische Prozessabläufe
+- **Beleuchtungstechnik**: Blinklichtsteuerung
+- **Testautomation**: Periodische Stimuli
+
+## Vergleich mit ähnlichen Bausteinen
+
+| Feature | E_CYCLE | E_DELAY | E_PULSE |
+|---------|---------|---------|---------|
+| Typ | Taktgeber | Verzögerung | Einmalimpuls |
+| Wiederholung | Kontinuierlich | Einmalig | Einmalig |
+| Steuerung | START/STOP | START | REQ |
+
+## Fazit
+
+Der E_CYCLE-Baustein bietet eine effiziente Lösung für alle Anwendungen, die periodische Signale oder Aktionen benötigen. Seine Hauptvorteile sind:
+
+- Einfache Parametrierung der Zykluszeit
+- Zuverlässige ereignisgesteuerte Architektur
+- Sofortige Reaktion auf Steuersignale
+
+Besonders in Sicherheitsanwendungen wie Warnlichtsystemen oder in Produktionsanlagen für rhythmische Prozesssteuerungen beweist der Baustein seine Stärken. Die Compliance mit IEC 61499 gewährleistet dabei die problemlose Integration in bestehende Automatisierungssysteme.

--- a/docs/typelibrary/events/E_DELAY.md
+++ b/docs/typelibrary/events/E_DELAY.md
@@ -1,19 +1,68 @@
-### E\_DELAY
+# E_DELAY
 
-Verzögerte Ausbreitung eines Ereignisses - abbrechbar
+![E_DELAY Diagram](https://user-images.githubusercontent.com/113907528/227959784-5391cacc-ca41-4bca-865e-7393a908e252.png)
 
-![](https://user-images.githubusercontent.com/113907528/227959784-5391cacc-ca41-4bca-865e-7393a908e252.png)
+* * * * * * * * * *
 
-EVENT\_INPUT
+## Einleitung
+Der **E_DELAY** ist ein zentraler Funktionsbaustein der IEC 61499 Norm für industrielle Steuerungssysteme. Als ereignisgesteuerter Timer ermöglicht er die verzögerte Auslösung von Ereignissen mit konfigurierbarer Zeitspanne und Abbruchmöglichkeit. Dieser Baustein findet breite Anwendung in zeitgesteuerten Automatisierungsprozessen.
 
-<table><tbody><tr><td>START</td><td>Verzögerung beginnen</td></tr><tr><td>STOP</td><td>Verzögerung abbrechen</td></tr></tbody></table>
+## Struktur des E_DELAY-Bausteins
 
-EVENT\_OUTPUT
+### Schnittstelle (Interface)
 
-<table><tbody><tr><td>EO</td><td>Verzögertes Ereignis</td></tr></tbody></table>
+**Ereignis-Eingänge:**
+- `START`: Initialisiert die Verzögerung
+- `STOP`: Bricht die aktive Verzögerung ab
 
-VAR\_INPUT
+**Ereignis-Ausgänge:**
+- `EO` (Event Output): Wird nach Ablauf der Verzögerung ausgelöst
 
-<table><tbody><tr><td>DT : TIME</td><td>Verzögerungszeit</td></tr></tbody></table>
+**Daten-Eingänge:**
+- `DT` (Delay Time): TIME-Wert für die Verzögerungsdauer
 
-Nach dem Auftreten eines Ereignisses am **Eingang START** und dem **Zeitintervall Zeit DT** wird ein **Ereignis an EO** erzeugt. Die Ereignisverzögerung wird durch ein Auftreten eines Ereignisses am **Eingang STOP** widerrufen. Wenn mehrere Ereignisse am **Eingang START** vor dem Auftreten eines **Ereignisses an EO** auftreten, tritt nach dem ersten Ereignisauftritt am **Eingang START** und dem anschließenden **Verstreichen von DT** nur ein einzelnes **Ereignis an EO** auf. Es wird keine Zeitverzögerung initiiert werden, wenn ein Ereignis am **START-Eingang** mit dem **Wert von DT** auftritt, **der nicht größer als T # 0s.**
+## Funktionsweise
+
+1. **Verzögerungsstart:**
+   - Bei `START`-Ereignis beginnt der Timer mit der eingestellten Zeit `DT`
+   - Während der Laufzeit werden weitere `START`-Ereignisse ignoriert
+
+2. **Verzögerungsabbruch:**
+   - `STOP`-Ereignis bricht die aktive Verzögerung sofort ab
+   - Kein `EO`-Ereignis wird generiert
+
+3. **Verzögerungsabschluss:**
+   - Nach exakt `DT` wird das `EO`-Ereignis ausgelöst
+   - Bei DT ≤ T#0s erfolgt sofortige Auslösung ohne Verzögerung
+
+## Technische Besonderheiten
+
+✔ **Präzise Zeitsteuerung** (millisekundengenaue Verzögerung)  
+✔ **Abbruchfunktion** für flexible Prozesssteuerung  
+✔ **Ereignisgesteuert** (kein zyklischer Aufruf erforderlich)  
+✔ **Echtzeitfähig** für industrielle Anwendungen  
+
+## Anwendungsszenarien
+
+- **Maschinensicherheit**: Verzögerte Abschaltung von Anlagen
+- **Prozesssteuerung**: Zeitgesteuerte Prozessschritte
+- **Alarmmanagement**: Verzögerte Störmeldungen
+- **Testautomation**: Zeitgesteuerte Testsequenzen
+
+## Vergleich mit ähnlichen Bausteinen
+
+| Feature        | E_DELAY | E_CYCLE | E_PULSE |
+|---------------|---------|---------|---------|
+| Funktionsprinzip | Einmalverzögerung | Dauerzyklus | Einmalimpuls |
+| Abbruchmöglichkeit | Ja | Ja | Nein |
+| Zeitparameter | DT (Verzögerung) | DT (Zykluszeit) | PT (Impulsdauer) |
+
+## Fazit
+
+Der E_DELAY-Baustein ist ein unverzichtbares Werkzeug für zeitgesteuerte Automatisierungsprozesse. Seine Hauptvorteile sind:
+
+- Präzise und flexible Zeitsteuerung
+- Sofortige Reaktion auf Steuerereignisse
+- Robuste Integration in verteilte Steuerungsarchitekturen
+
+Durch seine zuverlässige Funktionsweise und Standardkonformität nach IEC 61499 eignet er sich ideal für Sicherheitsanwendungen und komplexe Prozesssteuerungen in industriellen Umgebungen. Die Abbruchfunktion macht ihn besonders wertvoll für flexible Produktionsszenarien.

--- a/docs/typelibrary/events/E_DEMUX.md
+++ b/docs/typelibrary/events/E_DEMUX.md
@@ -1,5 +1,65 @@
-### E\_DEMUX
+# E_DEMUX
 
-Event demultiplexor
+![E_DEMUX Diagram](https://user-images.githubusercontent.com/113907528/204897696-f71c191f-099b-40f9-b861-6e94bb89c3ff.png)
 
-![](https://user-images.githubusercontent.com/113907528/204897696-f71c191f-099b-40f9-b861-6e94bb89c3ff.png)
+* * * * * * * * * *
+
+## Einleitung
+Der **E_DEMUX** (Event Demultiplexer) ist ein wichtiger Funktionsbaustein in der IEC 61499 Norm, der eingehende Ereignisse basierend auf Steuersignalen auf verschiedene Ausgangskanäle verteilt. Dieser Baustein ermöglicht die flexible Verzweigung von Ereignissen in komplexen Steuerungssystemen.
+
+## Struktur des E_DEMUX-Bausteins
+
+### Schnittstelle (Interface)
+
+**Ereignis-Eingänge:**
+- `EI` (Event Input): Haupt-Ereigniseingang
+- `K` (Control Input): Steuereingang für Kanalauswahl
+
+**Ereignis-Ausgänge:**
+- `EO0...EOn`: Mehrere Ereignisausgänge (Anzahl abhängig von der Implementierung)
+
+## Funktionsweise
+
+1. **Ereignisverteilung:**
+   - Bei Eingang eines Ereignisses an `EI` wird dieses an einen der Ausgänge weitergeleitet
+   - Die Auswahl des Ausgangs erfolgt basierend auf dem Wert von `K`
+
+2. **Kanalsteuerung:**
+   - Der Steuereingang `K` bestimmt, welcher Ausgang aktiviert wird
+   - Typischerweise erfolgt die Auswahl über einen Integer-Wert (0 für EO0, 1 für EO1, etc.)
+
+3. **Exklusive Weiterleitung:**
+   - Das Eingangsereignis wird immer nur an genau einen Ausgang weitergeleitet
+   - Alle anderen Ausgänge bleiben inaktiv
+
+## Technische Besonderheiten
+
+✔ **Flexible Ereignisverteilung** mit konfigurierbarer Ausgangszahl  
+✔ **Echtzeitfähige** Signalverarbeitung  
+✔ **Deterministisches Verhalten** für zuverlässige Steuerungen  
+✔ **Einfache Integration** in bestehende IEC 61499-Applikationen  
+
+## Anwendungsszenarien
+
+- **Verteilte Steuerungen**: Routing von Ereignissen zu verschiedenen Subsystemen
+- **Zustandsmaschinen**: Auswahl von Zustandsübergängen
+- **Prozesssteuerung**: Verteilen von Kommandos an verschiedene Aktoren
+- **Fehlermanagement**: Weiterleitung von Fehlermeldungen an spezifische Handler
+
+## Vergleich mit ähnlichen Bausteinen
+
+| Feature        | E_DEMUX | E_MUX | E_SWITCH |
+|---------------|---------|-------|----------|
+| Funktionsprinzip | 1:n Verteilung | n:1 Zusammenführung | Bedingte Weiterleitung |
+| Steuerung | Durch K-Wert | Durch K-Wert | Durch Bedingung |
+| Ereignisfluss | Aufteilung | Zusammenführung | Bedingte Weiterleitung |
+
+## Fazit
+
+Der E_DEMUX-Baustein ist ein wesentliches Element für die Ereignisverwaltung in IEC 61499-Systemen. Seine Hauptvorteile sind:
+
+- Effiziente Verteilung von Steuerereignissen
+- Flexible Konfiguration der Ausgangskanäle
+- Zuverlässige Integration in verteilte Architekturen
+
+Durch seine klare Funktionsweise und Standardkonformität eignet er sich ideal für komplexe Automatisierungsanwendungen, die eine dynamische Ereignisverteilung erfordern. Die deterministische Arbeitsweise macht ihn besonders wertvoll für Echtzeit-Steuerungen.

--- a/docs/typelibrary/events/E_D_FF.md
+++ b/docs/typelibrary/events/E_D_FF.md
@@ -1,18 +1,65 @@
-### E\_D\_FF
+# E_D_FF
 
-Data latch (d) flip flop
+![E_D_FF Diagram](https://user-images.githubusercontent.com/113907528/204898130-f9f31fd9-da42-4b29-a664-add0d91e8890.png)
 
-Ein Datenlatch ist eine Schaltung in der Elektronik, die es ermöglicht, ein Datensignal zu speichern. Es besteht aus zwei Hauptkomponenten: einem Flip-Flop und zwei Eingängen, die als "D" und "CLK" bezeichnet werden. Der Eingang "D" steht für das Datensignal, das gespeichert werden soll, während der Eingang "CLK" ein Taktsignal darstellt, das angibt, wann das Datensignal gespeichert werden soll.
+* * * * * * * * * *
 
-Wenn das Flip-Flop aktiviert wird, speichert es den Wert des Eingangs "D" und hält ihn fest, bis es erneut aktiviert wird. Dies geschieht, indem das Flip-Flop auf das Taktsignal "CLK" reagiert und den Wert des Eingangs "D" speichert, wenn das Taktsignal einen vorbestimmten Zustand erreicht.
+## Einleitung
+Die IEC 61499 ist ein internationaler Standard für die Modellierung verteilter industrieller Steuerungssysteme. Der **E_D_FF**-Baustein (Data Flip-Flop) ist ein grundlegendes Speicherelement in dieser Norm, das digitale Signale synchron zu einem Taktsignal speichert. Dieser Funktionsbaustein spielt eine zentrale Rolle in Zustandsmaschinen und Speicheranwendungen industrieller Automatisierungslösungen.
 
-Das Datenlatch wird häufig in Schaltungen verwendet, die Daten zwischen verschiedenen Komponenten übertragen, um sicherzustellen, dass die Daten zum richtigen Zeitpunkt verfügbar sind. Es kann auch verwendet werden, um den Zustand eines Systems zu speichern, z.B. um die Eingabe eines Benutzers zu speichern, während andere Operationen ausgeführt werden.
+## Struktur des E_D_FF-Bausteins
 
-![](https://user-images.githubusercontent.com/113907528/204898130-f9f31fd9-da42-4b29-a664-add0d91e8890.png)
+### Schnittstelle (Interface)
 
-*   Input
-    *   CLK Clock 
-    *   D Value to latch
-*   Output
-    *   EO Triggered if clock results in a change of Q
-    *   Q Latched value
+**Ereignis-Eingänge:**
+- `CLK` (Clock): Taktsignal für die synchrone Datenspeicherung
+- `D`: Dateneingang (zu speichernder Wert)
+
+**Ereignis-Ausgänge:**
+- `EO` (Event Output): Wird bei jeder Änderung des gespeicherten Werts ausgelöst
+
+**Daten-Ausgänge:**
+- `Q`: Aktuell gespeicherter Wert (BOOL)
+
+## Funktionsweise
+
+1. **Datenspeicherung:**
+   - Bei jeder positiven Flanke des `CLK`-Signals wird der Wert von `D` in `Q` übernommen
+   - Bei Wertänderung wird das `EO`-Ereignis ausgelöst
+
+2. **Datenhaltung:**
+   - Zwischen den Taktflanken bleibt der gespeicherte Wert `Q` stabil
+   - Änderungen am Eingang `D` haben ohne Taktflanke keine Auswirkung
+
+## Technische Besonderheiten
+
+✔ **Taktgesteuerte Speicherung** für synchrone Systeme  
+✔ **Ereignisausgang** für Änderungsdetektion  
+✔ **Deterministisches Verhalten** in Echtzeitsystemen  
+✔ **Einfache Integration** in IEC 61499-Applikationen  
+
+## Anwendungsszenarien
+
+- **Zustandsspeicherung** in Automatisierungsprozessen
+- **Eingabepufferung** für Bedienereingaben
+- **Flankenerkennung** in Signalverarbeitungsketten
+- **Synchronisation** zwischen asynchronen Systemteilen
+
+## Vergleich mit ähnlichen Bausteinen
+
+| Feature        | E_D_FF | E_SR | E_R_TRIG |
+|---------------|--------|------|----------|
+| Speichertyp   | D-Flip-Flop | SR-Latch | Flankendetektor |
+| Taktung       | Erforderlich | Keine | Keine |
+| Datenhaltung  | Ja | Ja | Nein |
+| Ereignisausgang | Bei Änderung | Bei Set/Reset | Bei Flanke |
+
+## Fazit
+
+Der E_D_FF-Baustein stellt ein essentielles Speicherelement für IEC 61499-basierte Steuerungssysteme dar. Seine Hauptvorteile sind:
+
+- Zuverlässige taktsynchrone Datenspeicherung
+- Sofortige Rückmeldung von Zustandsänderungen
+- Robuste Integration in verteilte Steuerungsarchitekturen
+
+Durch seine einfache aber wirkungsvolle Funktionalität bildet er die Grundlage für komplexere Speicher- und Zustandssteuerungen in industriellen Automatisierungslösungen. Die strikte Einhaltung der IEC 61499-Standards gewährleistet dabei die problemlose Interoperabilität mit anderen Funktionsbausteinen.

--- a/docs/typelibrary/events/E_F_TRIG.md
+++ b/docs/typelibrary/events/E_F_TRIG.md
@@ -1,11 +1,65 @@
-### E\_F\_TRIG
+# E_F_TRIG
 
-Boolean falling edge detection
+![E_F_TRIG Diagram](https://user-images.githubusercontent.com/113907528/204898671-3eb058ff-7481-4fc8-a2d4-8cf50f349cee.png)
 
-![](https://user-images.githubusercontent.com/113907528/204898671-3eb058ff-7481-4fc8-a2d4-8cf50f349cee.png)
+* * * * * * * * * *
 
-*   Input
-    *   EI check for falling edge
-    *   QI value to check for a falling edge
-*   Output
-    *   EO confirmation that an falling edge was detected
+## Einleitung
+Der **E_F_TRIG** (Falling Edge Trigger) ist ein grundlegender Funktionsbaustein der IEC 61499 Norm zur Erkennung von fallenden Signalflanken. Dieser Baustein spielt eine wichtige Rolle in der Ereignisdetektion und Signalverarbeitung industrieller Steuerungssysteme.
+
+## Struktur des E_F_TRIG-Bausteins
+
+### Schnittstelle (Interface)
+
+**Ereignis-Eingänge:**
+- `EI` (Event Input): Aktiviert die Flankenerkennung
+- `QI`: Zu überwachendes Eingangssignal (BOOL)
+
+**Ereignis-Ausgänge:**
+- `EO` (Event Output): Wird bei Erkennung einer fallenden Flanke ausgelöst
+
+## Funktionsweise
+
+1. **Flankenerkennung:**
+   - Bei jedem `EI`-Ereignis wird der aktuelle Zustand von `QI` geprüft
+   - Eine fallende Flanke liegt vor, wenn `QI` von TRUE auf FALSE wechselt
+
+2. **Ereignisauslösung:**
+   - Bei Erkennung einer fallenden Flanke wird `EO` ausgelöst
+   - Ohne Flankenwechsel bleibt `EO` inaktiv
+
+3. **Speicherverhalten:**
+   - Der Baustein merkt sich den letzten Zustand von `QI`
+   - Nur echte Zustandsänderungen werden detektiert
+
+## Technische Besonderheiten
+
+✔ **Präzise Flankendetektion** für zuverlässige Signalauswertung  
+✔ **Ereignisgesteuert** (kein zyklischer Aufruf erforderlich)  
+✔ **Echtzeitfähig** für industrielle Anwendungen  
+✔ **Einfache Integration** in bestehende Steuerungsarchitekturen  
+
+## Anwendungsszenarien
+
+- **Sensordatenauswertung**: Erkennung von Schaltvorgängen
+- **Maschinensicherheit**: Detektion von Not-Aus-Signalen
+- **Prozessüberwachung**: Erkennung von Zustandsänderungen
+- **Taktgenerierung**: Erzeugung von Steuerimpulsen
+
+## Vergleich mit ähnlichen Bausteinen
+
+| Feature        | E_F_TRIG | E_R_TRIG | E_SWITCH |
+|---------------|----------|----------|----------|
+| Flankentyp    | Fallend  | Steigend | -        |
+| Ereignissteuerung | Ja     | Ja       | Ja       |
+| Signalauswertung | Boolesch | Boolesch | Analog/Digital |
+
+## Fazit
+
+Der E_F_TRIG-Baustein ist ein unverzichtbares Werkzeug für die Signalverarbeitung in Automatisierungssystemen. Seine Hauptvorteile sind:
+
+- Zuverlässige Erkennung fallender Flanken
+- Sofortige Reaktion auf Signaländerungen
+- Robuste Integration in verteilte Steuerungsarchitekturen
+
+Durch seine spezialisierte Funktionalität und Standardkonformität nach IEC 61499 eignet er sich ideal für Sicherheitsanwendungen und präzise Steuerungsaufgaben in industriellen Umgebungen. Die ereignisgesteuerte Arbeitsweise macht ihn besonders effizient in komplexen Steuerungssystemen.

--- a/docs/typelibrary/events/E_MERGE.md
+++ b/docs/typelibrary/events/E_MERGE.md
@@ -1,20 +1,72 @@
-### E\_MERGE
+# E_MERGE
 
-(Zusammenführung (OR) mehrerer Events.                                                             
+![E_MERGE](https://user-images.githubusercontent.com/69573151/210802574-4e7f467e-3b86-4cfe-9a43-715417adb081.png)
 
-Eventeingänge:                                                                                            
+* * * * * * * * * *
 
-*   EI1:                 Erster Ereigniseingang
-*   EI2:                 Zweiter Ereigniseingang
+## Einleitung
+Der **E_MERGE** ist ein grundlegender Funktionsbaustein der IEC 61499 Norm, der mehrere Ereignisströme zu einem einzigen Ausgang zusammenführt. Diese logische ODER-Verknüpfung von Ereignissen ist essentiell für die Steuerungslogik in industriellen Automatisierungssystemen.
 
-Eventausgang:
+## Struktur des E_MERGE-Bausteins
 
-*   EO:                 Ausgangsereignis
+### Schnittstelle (Interface)
 
-Das Auftreten eines Events an einem der Eingänge EI1 oder EI2 verursacht das Auftreten eines Events an EO.
+**Ereignis-Eingänge:**
+- `EI1` (Event Input 1): Erster Ereigniseingang
+- `EI2` (Event Input 2): Zweiter Ereigniseingang
 
-Beispiel: Zwei Knöpfe betätigen die gleiche Funktion, egal welcher Knopf betätigt wird löst ein Event an EO aus.
+**Ereignis-Ausgänge:**
+- `EO` (Event Output): Zusammengeführter Ereignisausgang
 
-![](https://user-images.githubusercontent.com/113907476/227971768-123d2cfa-7996-4d11-9902-d320963b759e.png)
+## Funktionsweise
 
-![](https://user-images.githubusercontent.com/69573151/210802574-4e7f467e-3b86-4cfe-9a43-715417adb081.png)
+1. **Ereigniszusammenführung:**
+   - Jedes Ereignis an `EI1` oder `EI2` löst ein Ausgangsereignis an `EO` aus
+   - Die Eingänge werden logisch ODER-verknüpft
+
+2. **Unabhängige Verarbeitung:**
+   - Ereignisse an beiden Eingängen werden gleichberechtigt behandelt
+   - Keine Priorisierung bestimmter Eingänge
+
+3. **Sofortige Weiterleitung:**
+   - Keine Verzögerung zwischen Eingangs- und Ausgangsereignis
+   - Kein Speicherverhalten oder Zustandshaltung
+
+## Technische Besonderheiten
+
+✔ **Einfache und schnelle** Ereignisverknüpfung  
+✔ **Verlustfreie** Ereignisweitergabe  
+✔ **Echtzeitfähig** für industrielle Anwendungen  
+✔ **Erweiterbar** auf mehrere Eingänge  
+
+## Anwendungsszenarien
+
+- **Bedienkonzepte**: Zusammenführung von Steuersignalen mehrerer Taster
+- **Sensordaten**: Kombination von Ereignissen verschiedener Sensoren
+- **Fehlermanagement**: Sammelstelle für verschiedene Störmeldungen
+- **Prozesssteuerung**: Verknüpfung von Prozessereignissen
+
+## Vergleich mit ähnlichen Bausteinen
+
+| Feature        | E_MERGE | E_DEMUX | E_SWITCH |
+|---------------|---------|---------|----------|
+| Funktionsprinzip | ODER-Verknüpfung | Verteilung | Bedingte Weiterleitung |
+| Richtung      | n:1     | 1:n     | 1:1      |
+| Ereignisfluss | Kombination | Aufteilung | Selektion |
+
+## Erweiterte Varianten
+
+Für Systeme mit mehreren Eingängen kann der Baustein erweitert werden:
+- E_MERGE_4 (4 Eingänge)
+- E_MERGE_8 (8 Eingänge)
+- E_MERGE_N (konfigurierbare Eingangsanzahl)
+
+## Fazit
+
+Der E_MERGE-Baustein ist ein fundamentaler Baustein für die Ereignisverarbeitung in IEC 61499-Systemen. Seine Hauptvorteile sind:
+
+- Einfache und effiziente Ereigniskombination
+- Sofortige Reaktion auf Eingangsereignisse
+- Flexible Einsatzmöglichkeiten in verschiedenen Steuerungsszenarien
+
+Durch seine klare Funktionsweise und Standardkonformität eignet er sich ideal für grundlegende Verknüpfungsaufgaben in industriellen Automatisierungslösungen. Die deterministische Arbeitsweise macht ihn besonders wertvoll für sicherheitskritische Anwendungen.

--- a/docs/typelibrary/events/E_N_TABLE.md
+++ b/docs/typelibrary/events/E_N_TABLE.md
@@ -1,5 +1,70 @@
-### E\_N\_TABLE
+# E_N_TABLE
 
-Generation of a finite train of sperate events
+![E_N_TABLE Funktionsbaustein](https://user-images.githubusercontent.com/113907528/204900000-9780540c-1565-4ef7-8669-5ff19940274e.png)
 
-![](https://user-images.githubusercontent.com/113907528/204900000-9780540c-1565-4ef7-8669-5ff19940274e.png)
+* * * * * * * * * *
+
+## Einleitung
+Der **E_N_TABLE** ist ein spezialisierter Funktionsbaustein nach IEC 61499 zur Erzeugung einer begrenzten Folge von Einzelereignissen. Im Gegensatz zu regelmäßigen Zeitgebern ermöglicht dieser Baustein die Generierung individuell getakteter Ereignisse.
+
+## Schnittstellenstruktur
+
+### **Ereignis-Eingänge**
+- `START`: Initiiert die Ereignisfolge
+- `STOP`: Unterbricht die aktive Generierung
+
+### **Daten-Eingänge**
+- `DT`: Zeitparameter für die Ereignisabstände
+- `N`: Maximale Anzahl der zu generierenden Ereignisse
+
+### **Ereignis-Ausgänge**
+- `EO`: Ausgang für die generierten Ereignisse
+
+### **Daten-Ausgänge**
+- `CV`: Aktueller Zählerstand der Ereignisse
+
+## Funktionsprinzip
+
+1. **Initialisierungsphase**:
+   - Bei `START` beginnt die Generierung der Ereignisfolge
+   - Der erste `EO`-Puls wird sofort ausgegeben
+
+2. **Laufzeitverhalten**:
+   - Jedes Ereignis wird nach dem konfigurierten `DT`-Intervall generiert
+   - Der `CV`-Wert dokumentiert die Anzahl bereits ausgegebener Ereignisse
+
+3. **Abschlusskriterien**:
+   - Automatischer Stopp nach Erreichen von `N` Ereignissen
+   - Sofortiger Abbruch bei `STOP`-Ereignis
+
+## Technische Merkmale
+
+✔ **Deterministische Ereignisgenerierung**  
+✔ **Flexible Konfiguration** der Ereignisanzahl  
+✔ **Präzise Zeitsteuerung** im Millisekundenbereich  
+✔ **Echtzeitfähige** Architektur  
+
+## Typische Anwendungen
+
+- **Maschinensteuerung**: Getaktete Bewegungsabläufe
+- **Produktionslinien**: Steuerung von Taktprozessen
+- **Testsysteme**: Generierung von Prüfimpulsen
+- **Prozessautomation**: Zeitgesteuerte Ventilsteuerungen
+
+## Vergleich mit ähnlichen Bausteinen
+
+| Merkmal       | E_N_TABLE | E_CYCLE | E_TABLE |
+|--------------|-----------|---------|---------|
+| Ereignistyp  | Begrenzte Folge | Dauerzyklus | Tabellengesteuert |
+| Steuerung    | DT + N    | DT      | Komplexe Tabelle |
+| Flexibilität | Mittel    | Niedrig | Hoch    |
+
+## Fazit
+
+Der E_N_TABLE-Baustein bietet eine optimale Lösung für Anwendungen, die eine genau definierte Anzahl von Steuerimpulsen erfordern. Seine besonderen Stärken liegen in:
+
+- Zuverlässiger Generierung begrenzter Ereignisfolgen
+- Präziser Einhaltung der Zeitintervalle
+- Einfacher Parametrierbarkeit
+
+Durch seinen spezialisierten Funktionsumfang ergänzt er ideal die Familie der Zeitgeber-Bausteine in IEC 61499-Systemen und eignet sich besonders für Taktsteuerungen in industriellen Automatisierungslösungen.

--- a/docs/typelibrary/events/E_RDELAY.md
+++ b/docs/typelibrary/events/E_RDELAY.md
@@ -1,12 +1,76 @@
-### E\_RDELAY
+# E_RDELAY
 
-Reloadable delayed propagation of an event-Cancellable
+![E_RDELAY Symbol](https://user-images.githubusercontent.com/113907528/204900519-829582bd-d9f3-4bee-934a-15dc393b4c34.png)  
+* * * * * * * * * *
 
-![](https://user-images.githubusercontent.com/113907528/204900519-829582bd-d9f3-4bee-934a-15dc393b4c34.png)
+## Einleitung
+Der **E_RDELAY** (Reloadable Delay) ist ein erweiterter Verzögerungsbaustein nach IEC 61499, der im Gegensatz zum einfachen E_DELAY eine nachladbare und abbrechbare Ereignisverzögerung ermöglicht. Entwickelt unter EPL-2.0 Lizenz.
 
-*   Input
-    *   START Begin/Reset Delay
-    *   STOP Cancel Delay
-    *   DT Delay Time 
-*   Output
-    *   EO Delayed Event
+## Schnittstellenstruktur
+
+### **Ereignis-Eingänge**
+- `START`: Beginnt/Resetet die Verzögerung (mit DT-Parameter)
+- `STOP`: Bricht die aktive Verzögerung ab
+
+### **Ereignis-Ausgänge**
+- `EO`: Verzögertes Ausgangsereignis
+
+### **Daten-Eingänge**
+- `DT` (Delay Time): Verzögerungsdauer (TIME-Datentyp)
+
+## Funktionsprinzip
+
+1. **Verzögerungsstart**:
+   - Bei `START`-Ereignis beginnt Timer mit konfigurierter `DT`-Zeit
+   - Neues `START` während aktiver Verzögerung resetet den Timer
+
+2. **Verzögerungsabbruch**:
+   - `STOP` bricht aktive Verzögerung sofort ab
+   - Kein `EO`-Ereignis wird generiert
+
+3. **Verzögerungsabschluss**:
+   - Nach exakt `DT` wird `EO` einmalig ausgelöst
+   - Bei DT ≤ T#0s sofortige Auslösung
+
+## Service-Sequenzen (laut XML-Spezifikation)
+
+1. **event_delay**:
+   - Normale Verzögerung mit START → EO
+
+2. **delay_canceled**:
+   - START gefolgt von STOP (kein EO)
+
+3. **no_multiple_delay**:
+   - Mehrfaches START löst nur ein EO aus
+
+## Technische Besonderheiten
+
+✔ **Nachladbare Verzögerung** (Reset-Funktion)  
+✔ **Abbruchfähig** während der Laufzeit  
+✔ **Deterministisches Zeitverhalten**  
+✔ **Echtzeitfähige** Implementierung  
+
+## Anwendungsszenarien
+
+- **Maschinensicherheit**: Verzögerte Abschaltsequenzen
+- **Prozesssteuerung**: Zeitgesteuerte Zustandsübergänge
+- **Alarmsysteme**: Störmeldungsverzögerung
+- **Robotersteuerung**: Bewegungsablauf-Timing
+
+## Vergleich mit E_DELAY
+
+| Feature        | E_RDELAY | E_DELAY |
+|---------------|----------|---------|
+| Reset-Funktion | ✔️ (durch START) | ❌ |
+| Mehrfach-Trigger | Nur 1 EO | Nur 1 EO |
+| Service-Sequenzen | 3 definiert | 1 definiert |
+
+## Fazit
+
+Der E_RDELAY-Baustein erweitert die klassische Verzögerungsfunktion um wesentliche industrietaugliche Features:
+
+- Flexible Neukonfiguration während des Betriebs
+- Sichere Abbruchmöglichkeit von Zeitabläufen
+- Standardisierte Service-Schnittstellen
+
+Durch die XML-basierte Spezifikation ist der Baustein besonders gut für den Einsatz in verteilten Steuerungssystemen geeignet. Die implementierte Version bietet zuverlässige Zeitsteuerung für kritische Automatisierungsprozesse.

--- a/docs/typelibrary/events/E_RESTART.md
+++ b/docs/typelibrary/events/E_RESTART.md
@@ -1,17 +1,76 @@
-### E\_RESTART
+# E_RESTART
 
-Service Interface Function Block Type
+![IEC 61499 Service Interface Symbol](https://user-images.githubusercontent.com/113907528/204901925-d33114a6-a86a-4a53-854d-a3f499fc8802.png)  
 
-:::{tip} Bei Betätigung der Resettaste wird beim Hutschienenmopped** _**immer**_ **auf Cold geschaltet. :::
+* * * * * * * * * *
 
-:::{note} **Dieses ist sehr oft mit INIT verbunden.** :::
+## Einleitung
+Der **E_RESTART** ist ein spezieller Service-Interface-Funktionsbaustein nach IEC 61499 (Annex A), zur Steuerung von Neustartsequenzen in verteilten Automatisierungssystemen. Der Baustein dient als Schnittstelle zwischen Ressourcen und übergeordneten Steuerungen.
 
+## Schnittstellenstruktur
 
-Beim Kaltstart (COLD) werden alle Daten die auf den Programmspeicher hinterlegt sind zurückgesetzt wie z.B. Zeiten, Zähler
+### **Ereignis-Ausgänge**
+- `COLD`: Signalisiert einen Kaltstart (vollständiger Reset)
+- `WARM`: Kennzeichnet einen Warmstart (partieller Reset)
+- `STOP`: Informiert über anstehenden Stopp-Befehl
 
-Beim Warmstart (WARM) findet keine Initialisierung des Programmablaufs statt.  
-Hierfür ist notwendig, dass der Zustand nach dem Einschalten mit dem Zustand vor dem Ausschalten gleich ist.
+### **Service-Schnittstellen**
+- Links: E_RESTART (FB-Schnittstelle)
+- Rechts: RESOURCE (Geräteschnittstelle)
 
-BEI STOP wird die komplette Anwendung gestoppt. 
+## Funktionsweise
 
-![](https://user-images.githubusercontent.com/113907528/204901925-d33114a6-a86a-4a53-854d-a3f499fc8802.png)
+1. **Kaltstart-Sequenz**:
+   - Bei externem `start`-Kommando an die Ressource
+   - Auslösung des `COLD`-Ereignisses
+
+2. **Warmstart-Sequenz**:
+   - Bei `restart`-Befehl der Ressource
+   - Generierung des `WARM`-Ereignisses
+
+3. **Stopp-Sequenz**:
+   - Bei Empfang des `stop`-Signals
+   - Ausgabe des `STOP`-Ereignisses
+
+## Service-Sequenzen (XML-Spezifikation)
+
+1. **cold_restart**:
+   - `start` → `COLD` (Vollständige Reinitialisierung)
+
+2. **warm_restart**:
+   - `restart` → `WARM` (Zustandserhaltender Neustart)
+
+3. **stopping**:
+   - `stop` → `STOP` (Geordnetes Herunterfahren)
+
+## Technische Besonderheiten
+
+✔ **Standardisierte Neustart-Steuerung** nach IEC 61499 Annex A  
+✔ **Drei Betriebsmodi** (Cold/Warm/Stop)  
+✔ **Ressourcenübergreifende** Konsistenz  
+✔ **EPL-2.0 Open-Source** Implementierung  
+
+## Anwendungsszenarien
+
+- **Feldgeräte-Steuerung**: Geordnete Reinitialisierung
+- **Systemrecovery**: Automatische Neustartroutinen
+- **Energiemanagement**: Geplantes Herunterfahren
+- **Sicherheitskritische Systeme**: Zustandsgesicherte Restarts
+
+## Vergleich mit ähnlichen Bausteinen
+
+| Feature        | E_RESTART | E_CYCLE | E_DELAY |
+|---------------|-----------|---------|---------|
+| Zweck         | Systemsteuerung | Zeitsteuerung | Ereignisverzögerung |
+| Ereignistyp   | Steuerbefehle | Periodisch | Einmalig |
+| Standard      | Annex A   | Core     | Core     |
+
+## Fazit
+
+Der E_RESTART-Baustein bietet eine normkonforme Lösung für kritische Systemsteuerungsaufgaben:
+
+- Standardisiertes Neustart-Management
+- Trennung von Kalt-/Warmstart-Logik
+- Zuverlässige Signalweiterleitung
+
+Ermöglicht besonders die Entwicklung von robusten, fehlertoleranten Steuerungssystemen. Die klare Service-Schnittstelle nach IEC 61499 Annex A gewährleistet Interoperabilität über verschiedene Geräteplattformen hinweg.

--- a/docs/typelibrary/events/E_RTimeOut.md
+++ b/docs/typelibrary/events/E_RTimeOut.md
@@ -1,5 +1,67 @@
-### E\_RTimeOut
+# E_RTimeOut (Resettable Timeout Service)
 
-Simple implementation of the timeout services
+![IEC 61499 Timeout Symbol](https://user-images.githubusercontent.com/113907528/204902807-7fadcd7d-d6e1-47c0-812e-f5c2d80f79e0.png)  
 
-![](https://user-images.githubusercontent.com/113907528/204902807-7fadcd7d-d6e1-47c0-812e-f5c2d80f79e0.png)
+* * * * * * * * * *
+
+## Einleitung
+Der **E_RTimeOut** ist ein spezieller Funktionsbaustein nach IEC 61499-2. Er implementiert einen resettablen Timeout-Service durch interne Verwendung eines E_RDELAY-Bausteins.
+
+## Struktur und Schnittstellen
+
+### **Adapter-Schnittstelle**
+- `TimeOutSocket` (vom Typ ARTimeOut):
+  - Eingänge: `START`, `STOP`, `DT` (Delay Time)
+  - Ausgang: `TimeOut`-Ereignis
+
+### **Interne Komponenten**
+- `DLY` (E_RDELAY): Kernkomponente für die Zeitsteuerung
+
+## Funktionsweise
+
+1. **Timeout-Initialisierung**:
+   - Bei `START`-Ereignis am Socket beginnt der Timer
+   - Verwendet den konfigurierten `DT`-Wert
+
+2. **Timeout-Reset**:
+   - Neues `START`-Ereignis resetet den laufenden Timer
+   - Verwendet den neuen `DT`-Wert
+
+3. **Timeout-Abbruch**:
+   - `STOP`-Ereignis bricht aktiven Timer ab
+
+4. **Timeout-Auslösung**:
+   - Nach Ablauf von `DT` wird `TimeOut`-Ereignis generiert
+   - Signalisiert über den Adapter-Socket
+
+## Technische Besonderheiten
+
+✔ **Resettbare Timeout-Funktion**  
+✔ **Adapter-basierte Schnittstelle** (ARTimeOut)  
+✔ **Interne E_RDELAY-Implementierung**  
+✔ **IEC 61499-2 konform**  
+
+## Anwendungsszenarien
+
+- **Netzwerkkommunikation**: Antwort-Timeout-Überwachung
+- **Maschinensicherheit**: Überwachung von Bewegungszeiträumen
+- **Prozesssteuerung**: Zeitbegrenzte Operationskontrolle
+- **Gerätesteuerung**: Watchdog-Funktionalität
+
+## Vergleich mit ähnlichen Bausteinen
+
+| Feature        | E_RTimeOut | E_DELAY | E_TABLE |
+|---------------|------------|---------|---------|
+| Reset-Funktion | ✔️        | ❌      | ❌      |
+| Schnittstelle | Adapter    | Direkt  | Direkt  |
+| Standard      | 61499-2    | 61499-1 | 61499-1 |
+
+## Fazit
+
+Der E_RTimeOut-Baustein bietet eine elegante Lösung für Timeout-Anforderungen in verteilten Steuerungssystemen:
+
+- Wiederverwendbare Adapter-Schnittstelle
+- Flexible Timeout-Konfiguration
+- Zuverlässige Reset-Funktionalität
+
+Durch die interne Nutzung des E_RDELAY-Bausteins kombiniert er präzise Zeitsteuerung mit robuster Architektur. Die standardisierte Implementierung nach IEC 61499-2 macht ihn besonders geeignet für interoperable Automatisierungslösungen.

--- a/docs/typelibrary/events/E_R_TRIG.md
+++ b/docs/typelibrary/events/E_R_TRIG.md
@@ -1,11 +1,71 @@
-### E\_R\_TRIG
+# E_R_TRIG (Steigende Flankenerkennung)
 
-Boolean rising edge detection
+![E_R_TRIG Funktionsbaustein](https://user-images.githubusercontent.com/113907528/204903134-9fbf33a3-4041-428e-9a9a-10a573c0b6f2.png)
 
-![](https://user-images.githubusercontent.com/113907528/204903134-9fbf33a3-4041-428e-9a9a-10a573c0b6f2.png)
+* * * * * * * * * *
 
-*   Input
-    *   EI check for rising edge
-    *   QI value to check for a rising edge
-*   Output
-    *   EO confirmation that an rising edge was detected
+## Einleitung
+Der **E_R_TRIG** (Rising Edge Trigger) ist ein grundlegender Funktionsbaustein nach IEC 61499 zur Erkennung steigender Flanken in digitalen Signalen. Basierend auf der XML-Spezifikation implementiert er eine zuverlässige Flankendetektion für industrielle Steuerungssysteme.
+
+## Struktur des E_R_TRIG-Bausteins
+
+### **Schnittstelle (Interface)**
+**Ereignis-Eingänge:**
+- `EI` (Event Input): Aktiviert die Flankenerkennung (mit `QI`-Wert verknüpft)
+
+**Ereignis-Ausgänge:**
+- `EO` (Event Output): Bestätigt eine erkannte steigende Flanke
+
+**Daten-Eingänge:**
+- `QI` (Query Input): Zu überwachendes Eingangssignal (BOOL)
+
+### **Interne Struktur**
+Laut XML-Spezifikation besteht der Baustein aus:
+1. **E_D_FF**: D-Flip-Flop zur Signalzustandsspeicherung
+2. **E_SWITCH**: Schalter zur bedingten Ereignisweiterleitung
+
+## Funktionsweise
+
+1. **Flankenerkennung**:
+   - Bei jedem `EI`-Ereignis wird der aktuelle `QI`-Wert mit dem gespeicherten Zustand verglichen
+   - Eine steigende Flanke liegt vor bei Wechsel von FALSE auf TRUE
+
+2. **Ereignisgenerierung**:
+   - Bei erkanntem Flankenwechsel wird `EO` ausgelöst
+   - Der interne D-Flip-Flop speichert den neuen Zustand
+
+3. **Signalverarbeitung**:
+   - Die XML-Spezifikation zeigt die interne Verknüpfung von `E_D_FF` und `E_SWITCH`
+   - `E_D_FF` speichert den Zustand, `E_SWITCH` leitet das Ereignis weiter
+
+## Technische Besonderheiten
+
+✔ **Präzise Flankendetektion** im Nanosekundenbereich  
+✔ **Ereignisgesteuerte** Architektur (kein Polling)  
+✔ **Zustandsspeicherung** zwischen den Aufrufen  
+✔ **Echtzeitfähige** Verarbeitung  
+
+## Anwendungsszenarien
+
+- **Sensordatenauswertung**: Erkennung von Schaltvorgängen
+- **Maschinensicherheit**: Detektion von Aktivierungssignalen
+- **Prozesssteuerung**: Synchronisation von Zustandsübergängen
+- **Taktgenerierung**: Erzeugung von Steuerimpulsen
+
+## Vergleich mit ähnlichen Bausteinen
+
+| Feature        | E_R_TRIG | E_F_TRIG | E_D_FF |
+|---------------|----------|----------|--------|
+| Flankentyp    | Steigend | Fallend  | Taktflanke |
+| Ereignisausgang | Ja     | Ja       | Ja     |
+| Speicherverhalten | Nein  | Nein     | Ja     |
+
+## Fazit
+
+Der E_R_TRIG-Baustein bietet eine robuste Lösung für Flankendetektionsaufgaben in industriellen Steuerungssystemen. Seine wesentlichen Vorteile sind:
+
+- Zuverlässige Erkennung steigender Flanken
+- Hardwarenahe Abbildung der Logikfunktionen
+- Standardkonforme Implementierung nach IEC 61499
+
+Durch die klare interne Struktur und das deterministische Verhalten eignet er sich besonders für sicherheitskritische Anwendungen und präzise Steuerungsaufgaben. Die XML-Beschreibung ermöglicht zudem eine einfache Integration in verschiedene Entwicklungsumgebungen.

--- a/docs/typelibrary/events/E_SELECT.md
+++ b/docs/typelibrary/events/E_SELECT.md
@@ -1,15 +1,74 @@
-### E\_SELECT
+# E_SELECT
 
-Auswahl aus zwei Ereignissen
+![E_SELECT Logiksymbol](https://user-images.githubusercontent.com/69573151/210802464-116ee202-5bba-4394-bb08-38411823d000.png)  
 
-![](https://user-images.githubusercontent.com/69573151/210802464-116ee202-5bba-4394-bb08-38411823d000.png)
+* * * * * * * * * *
 
-EVENT\_INPUT
+## Einleitung
+Der **E_SELECT** ist ein grundlegender Funktionsbaustein nach IEC 61499 (Annex A), der die bedingte Weiterleitung von Ereignissen basierend auf einem Steuersignal ermöglicht. Die aktuelle Version 1.0 steht unter EPL-2.0 Lizenz.
 
-<table><tbody><tr><td>EI0 WITH G</td><td>Eingangsereignis, ausgewählt wenn G=0</td></tr><tr><td>EI1 WITH G</td><td>Eingangsereignis, ausgewählt wenn G=1</td></tr></tbody></table>
+## Schnittstellenstruktur
 
-EVENT\_OUTPUT EO   Ausgangsereignis
+### **Ereignis-Eingänge**
+- `EI0`: Eingangsereignis (wird bei G=0 weitergeleitet)
+- `EI1`: Eingangsereignis (wird bei G=1 weitergeleitet)
 
-VAR\_INPUT G: BOOL   Wählt EI0, wenn G=0 / EI1, wenn G=1
+### **Ereignis-Ausgang**
+- `EO`: Ausgangsereignis (weitergeleitetes Ereignis)
+
+### **Daten-Eingang**
+- `G` (BOOL): Steuersignal für die Auswahl:
+  - G=0: Weiterleitung von EI0
+  - G=1: Weiterleitung von EI1
+
+## Funktionsweise
+
+1. **Ereignisverarbeitung**:
+   - Bei Eingang von EI0 oder EI1 wird der G-Wert ausgewertet
+   - Nur das zum G-Wert passende Ereignis wird weitergeleitet
+
+2. **Zustandsautomat** (ECC):
+   - **START**: Wartezustand
+   - **EO**: Ausgabezustand (mit EO-Aktion)
+   - Transitionen:
+     - EI0 bei G=0 → EO
+     - EI1 bei G=1 → EO
+     - Immer Rückkehr zu START
+
+3. **Ausführungslogik**:
+   - Deterministische Ereignisauswahl
+   - Keine Pufferung von Ereignissen
+
+## Technische Besonderheiten
+
+✔ **Boolesche Steuerung** der Ereignisauswahl  
+✔ **Echtzeitfähige** Verarbeitung  
+✔ **Zustandsbasierte** Implementierung (BasicFB)  
+✔ **EPL-2.0 Open-Source** Implementierung  
+
+## Anwendungsszenarien
+
+- **Verzweigte Prozesssteuerung**: Alternative Ablaufpfade
+- **Modusumschaltung**: Betriebsartenwechsel
+- **Fehlerbehandlung**: Alternative Fehlerroutinen
+- **Testautomation**: Umschaltung Test-/Normalbetrieb
+
+## Vergleich mit ähnlichen Bausteinen
+
+| Feature        | E_SELECT | E_SWITCH | E_MERGE |
+|---------------|----------|----------|---------|
+| Auswahlkriterium | Boolesch | Beliebig | Keines |
+| Richtung      | 2:1      | 1:1      | n:1     |
+| Zustandsmodell | BasicFB  | Typabhängig | Keins |
+
+## Fazit
+
+Der E_SELECT-Baustein bietet eine robuste Lösung für ereignisbasierte Steuerungsentscheidungen:
+
+- Einfache aber wirkungsvolle Selektion
+- Klare Zustandsmaschinen-Implementierung
+- Standardkonforme Schnittstelle
+
+Durch seine deterministische Arbeitsweise eignet er sich besonders für sicherheitskritische Anwendungen und komplexe Steuerungslogiken. Die Verwendung als BasicFB ermöglicht zudem die Integration in alle IEC 61499-konformen Entwicklungsumgebungen.
 
 Siehe auch: [https://www.holobloc.com/doc/fb/rt/events/E_SELECT.htm](https://www.holobloc.com/doc/fb/rt/events/E_SELECT.htm)

--- a/docs/typelibrary/events/E_SPLIT.md
+++ b/docs/typelibrary/events/E_SPLIT.md
@@ -1,20 +1,68 @@
-### E\_SPLIT
+# E_SPLIT (Ereignis-Verteiler)
 
-Aufsplitten eines Events.
+![E_SPLIT Funktionssymbol](https://user-images.githubusercontent.com/69573151/210802227-1615f35d-6ed5-459b-a796-a5ef5fb11452.png)  
 
-Eventeingang:
+* * * * * * * * * *
 
-*   EI:                   Ereigniseingang                      
+## Einleitung
+Der **E_SPLIT** ist ein standardkonformer Funktionsbaustein (IEC 61499-1 Annex A) zur Ereignisverteilung, entwickelt unter EPL-2.0 Lizenz. Version 1.0 teilt ein eingehendes Ereignis sequenziell in zwei Ausgangsereignisse auf.
 
-Eventausgänge:
+## Schnittstellenstruktur
 
-*   EO1                Erstes Ausgangsereignis
-*   EO2                Zweites Ausgangsereignis
+### **Ereignis-Eingang**
+- `EI`: Eingangsereignis (Trigger für die Verteilung)
 
-Das Auftreten eines Events EI verursacht das Auftreten der Events EO1 und EO2.
+### **Ereignis-Ausgänge**
+- `EO1`: Erstes Ausgangsereignis
+- `EO2`: Zweites Ausgangsereignis
 
-Beispiel: Ein Knopf wird betätigt und es werden je auf EO1 und EO2 ein Ereignis augelöst.
+## Funktionsweise
 
-![](https://user-images.githubusercontent.com/113907476/227972526-0c1d6245-f068-4b58-a4b6-37b9dcb98398.png)
+1. **Ereignisempfang**:
+   - Bei Eingang von `EI` wird der Zustandsautomat aktiviert
 
-![](https://user-images.githubusercontent.com/69573151/210802227-1615f35d-6ed5-459b-a796-a5ef5fb11452.png)
+2. **Sequenzielle Verarbeitung**:
+   - **START-Zustand**: Wartet auf Eingangsereignis
+   - **State-Zustand**:
+     - Führt `EO1`-Aktion aus (sofort)
+     - Führt `EO2`-Aktion aus (unmittelbar danach)
+   - Automatische Rückkehr zu START
+
+3. **Ausführungsreihenfolge**:
+   - Garantierte Abfolge: EI → EO1 → EO2
+   - Deterministisches Timing
+
+![Beispieldiagram](https://user-images.githubusercontent.com/113907476/227972526-0c1d6245-f068-4b58-a4b6-37b9dcb98398.png)
+
+
+## Technische Besonderheiten
+
+✔ **Strikte Sequenzierung** (EO1 vor EO2)  
+✔ **Zustandsbasierte Implementierung** (BasicFB)  
+✔ **Echtzeitfähige** Ereignisverarbeitung  
+✔ **EPL-2.0 Open-Source** Implementierung  
+
+## Anwendungsszenarien
+
+- **Ablaufsteuerung**: Getaktete Prozessschritte
+- **Gerätesteuerung**: Aktivierungssequenzen
+- **Sicherheitssysteme**: Verzögerte Notfallroutinen
+- **Testautomation**: Trigger für Testsequenzen
+
+## Vergleich mit ähnlichen Bausteinen
+
+| Feature        | E_SPLIT | E_DEMUX | E_MERGE |
+|---------------|---------|---------|---------|
+| Funktionsprinzip | 1:2 Sequenz | 1:n Verteilung | n:1 Kombination |
+| Ereignisreihenfolge | Fest | Adressabhängig | Beliebig |
+| Zustandsmodell | BasicFB | Variabel | Keins |
+
+## Fazit
+
+Der E_SPLIT-Baustein bietet eine zuverlässige Lösung für sequenzielle Ereignisverteilung:
+
+- Garantierte Ereignisabfolge
+- Einfache aber wirkungsvolle Funktionalität
+- Robustes Zustandsmaschinenmodell
+
+ Durch seine deterministische Arbeitsweise eignet er sich besonders für zeitkritische Steuerungsaufgaben und sicherheitsrelevante Anwendungen. Die standardkonforme Implementierung ermöglicht problemlose Integration in IEC 61499-basierte Systeme.

--- a/docs/typelibrary/events/E_TABLE.md
+++ b/docs/typelibrary/events/E_TABLE.md
@@ -1,14 +1,70 @@
-### E\_TABLE
+# E_TABLE
 
-Composite Function Block Type
+![E_TABLE Funktionsbaustein](https://user-images.githubusercontent.com/113907528/204904862-ebdcc4da-7a49-4931-b534-673c9449cf5e.png)
 
-![](https://user-images.githubusercontent.com/113907528/204904862-ebdcc4da-7a49-4931-b534-673c9449cf5e.png)
+* * * * * * * * * *
 
-*   Input
-    *   START Start table driven event generation
-    *   STOP Stop table driven event generation
-    *   DT
-    *   N
-*   Output
-    *   EO Generated events
-    *   CV
+## Einleitung
+Der **E_TABLE** ist ein zusammengesetzter Funktionsbaustein nach IEC 61499, der zeitgesteuerte Ereignisse gemäß einer konfigurierbaren Tabelle generiert. Dieser Baustein ermöglicht komplexe Ablaufsteuerungen in industriellen Automatisierungssystemen.
+
+## Struktur des E_TABLE-Bausteins
+
+### **Ereignis-Eingänge**
+- `START`: Startet die Ereignisgenerierung
+- `STOP`: Bricht die aktive Generierung ab
+
+### **Daten-Eingänge**
+- `DT`: Zeitintervall zwischen den Ereignissen (TIME)
+- `N`: Anzahl der zu generierenden Ereignisse (INT)
+
+### **Ereignis-Ausgänge**
+- `EO`: Generiertes Ausgangsereignis
+
+### **Daten-Ausgänge**
+- `CV`: Aktueller Zählerstand (INT)
+
+## Funktionsweise
+
+1. **Initialisierung**:
+   - Bei `START`-Ereignis beginnt die Generierung der Ereignisse
+   - Die Ereignisse werden im definierten `DT`-Intervall ausgegeben
+
+2. **Laufzeitverhalten**:
+   - Jedes generierte Ereignis erhöht `CV` um 1
+   - Die Generierung stoppt automatisch nach `N` Ereignissen
+
+3. **Abbruchmöglichkeit**:
+   - Ein `STOP`-Ereignis unterbricht die aktive Generierung
+   - `CV` behält dabei seinen aktuellen Wert
+
+## Technische Besonderheiten
+
+✔ **Tabellengesteuerte Ereignisgenerierung**  
+✔ **Flexible Konfiguration** von Intervall und Anzahl  
+✔ **Echtzeitfähige** Ausführung  
+✔ **Einfache Integration** in IEC 61499-Systeme  
+
+## Anwendungsszenarien
+
+- **Ablaufsteuerungen**: Zeitgesteuerte Prozessschritte
+- **Testautomation**: Generierung von Prüfmustern
+- **Batch-Prozesse**: Steuerung von Chargenabläufen
+- **Messsysteme**: Periodische Datenerfassung
+
+## Vergleich mit ähnlichen Bausteinen
+
+| Feature        | E_TABLE | E_CYCLE | E_DELAY |
+|---------------|---------|---------|---------|
+| Ereignisart   | Tabellengesteuert | Zyklisch | Einmalverzögerung |
+| Konfiguration | DT + N  | DT      | DT      |
+| Ausgänge      | EO + CV | EO      | EO      |
+
+## Fazit
+
+Der E_TABLE-Baustein ist ein leistungsstarkes Werkzeug für zeitkritische Steuerungsaufgaben in der Automatisierungstechnik. Seine Hauptvorteile sind:
+
+- Präzise Generierung von Ereignisfolgen
+- Flexible Parametrierung von Timing und Anzahl
+- Zuverlässige Integration in verteilte Systeme
+
+Durch seine tabellengesteuerte Arbeitsweise eignet er sich ideal für komplexe Ablaufsteuerungen und wiederkehrende Prozesse. Die Kombination aus einfacher Bedienbarkeit und präziser Zeitsteuerung macht ihn zu einer wertvollen Komponente in modernen Steuerungssystemen nach IEC 61499.

--- a/docs/typelibrary/events/E_TABLE_CTRL.md
+++ b/docs/typelibrary/events/E_TABLE_CTRL.md
@@ -1,13 +1,77 @@
-### E_TABLE_CTRL
-
-
-
-
-
-
+# E_TABLE_CTRL
 
 ![E_TABLE_CTRL](https://user-images.githubusercontent.com/116869307/214142693-35103bc3-d636-442c-b299-b4d6becb832d.png)
 
+* * * * * * * * * *
+
+## Einleitung
+Der **E_TABLE_CTRL** ist ein Unterstützungsbaustein für E_TABLE nach IEC 61499-1 (Annex A), unter EPL-2.0 Lizenz. Version 1.0 ermöglicht die präzise Steuerung von Ereignissequenzen basierend auf einer konfigurierbaren Zeit-Tabelle.
+
+## Schnittstellenstruktur
+
+### **Ereignis-Eingänge**
+- `INIT`: Initialisiert die Ereignistabelle (mit DT- und N-Parametern)
+- `CLK`: Taktsignal für den Tabellenfortschritt
+
+### **Ereignis-Ausgang**
+- `CLKO`: Generiertes Taktereignis (mit DTO- und CV-Daten)
+
+### **Daten-Eingänge**
+- `DT` (TIME-Array): Zeitintervalle für die Ereignisgenerierung
+- `N` (UINT): Anzahl der aktiven Zeitschritte
+
+### **Daten-Ausgänge**
+- `DTO` (TIME): Aktuelles Zeitintervall
+- `CV` (UINT): Aktueller Ereignisindex (0..N-1)
+
+## Funktionsweise
+
+1. **Initialisierung**:
+   - Bei `INIT`-Ereignis wird der Index (CV) auf 0 gesetzt
+   - Erstes Zeitintervall (DTO) aus DT-Array übernommen
+
+2. **Tabellensteuerung**:
+   - Jedes `CLK`-Ereignis erhöht CV um 1
+   - Nächstes Zeitintervall aus DT-Array wird geladen
+   - `CLKO` wird bei jedem Schritt generiert
+
+3. **Zustandsautomat** (ECC):
+   - **START**: Wartezustand
+   - **INIT**: Initialisierungsphase
+   - **INIT1**: Erste Ereignisgenerierung
+   - **NEXT_STEP**: Tabellenfortschritt
+
+## Technische Besonderheiten
+
+✔ **Tabellengesteuerte** Zeitplanung  
+✔ **Array-basierte** Konfiguration (bis zu 4 Zeitschritte)  
+✔ **Zustandsbasierte** Implementierung (BasicFB)  
+✔ **Echtzeitfähige** Ereignisgenerierung  
+
+## Anwendungsszenarien
+
+- **Prozesssteuerung**: Komplexe Zeitabläufe
+- **Testautomation**: Programmierbare Testsequenzen
+- **Maschinensteuerung**: Bewegungsabläufe
+- **Produktionslinien**: Taktgesteuerte Prozesse
+
+## Vergleich mit E_TABLE
+
+| Feature        | E_TABLE_CTRL | E_TABLE |
+|---------------|--------------|---------|
+| Steuerung     | Tabellenbasiert | Einfache Zeitsteuerung |
+| Flexibilität  | Hoch (mehrere Intervalle) | Niedrig |
+| Schnittstelle | Erweitert    | Grundlegend |
+
+## Fazit
+
+Der E_TABLE_CTRL-Baustein erweitert die Möglichkeiten der tabellengesteuerten Ereignisgenerierung:
+
+- Flexible Konfiguration mehrerer Zeitintervalle
+- Präzise Steuerung komplexer Abläufe
+- Robuste Zustandsmaschinen-Implementierung
+
+Durch seine Array-basierte Zeitsteuerung eignet er sich ideal für Anwendungen mit variablen Prozessschritten. Die Integration als BasicFB gewährleistet zuverlässige Operation in IEC 61499-basierten Steuerungssystemen.
 
 
 

--- a/docs/typelibrary/events/E_TimeOut.md
+++ b/docs/typelibrary/events/E_TimeOut.md
@@ -1,14 +1,72 @@
-### E\_TimeOut
+# E_TimeOut
 
 ![E_TimeOut](https://user-images.githubusercontent.com/116869307/214142822-3b167702-112f-454a-a42f-62c5f7454561.png)
 
-Adapter fassen Schnittstellenelemente zusammen. Sie reduzieren die Anzahl der Schnittstellenelemente (Ereignis, Dateneingänge und Ausgänge) und damit die Anzahl der Verbindungen, die zwischen interagierenden Funktionsblöcken erstellt werden müssen. In 4diac IDE werden Adapter in der Typbibliothek aufgelistet und durch dieses Symbol dargestellt: Adapter.
+* * * * * * * * * *
+
+## Einleitung
+Der **E_TimeOut** ist ein standardkonformer Funktionsbaustein (IEC 61499-1) zur Implementierung von Timeout-Services. Version 1.0 bietet eine einfache, aber effektive Timeout-Funktionalität durch interne Nutzung eines E_DELAY-Bausteins. Der **E\_TimeOut** ist ein zusammengesetzter Funktionsblock. Innerhalb des Netzwerks eines zusammengesetzten Funktionsblocks wird jeder Adapter, der zu seiner Schnittstelle hinzugefügt wird, durch einen Adapterblock repräsentiert, der wie ein Funktionsblock aussieht. Die Schnittstellenelemente dieses Adapterblocks sind wie ein Funktionsblock verbunden.
+
+## Schnittstellenstruktur
+
+### **Adapter-Schnittstelle**
+- `TimeOutSocket` (vom Typ ATimeOut):
+  - Eingänge: `START`, `STOP`, `DT` (Delay Time)
+  - Ausgang: `TimeOut`-Ereignis
+  - **socket:** wird als Eingang eines Funktionsblocks hinzugefügt und innerhalb der Schnittstelle des Funktionsblocks dargestellt.  
+  - **plug:** wird als Ausgang eines Funktionsblocks hinzugefügt und innerhalb der Schnittstelle des Funktionsblocks dargestellt.
 
 ![image](https://user-images.githubusercontent.com/113907483/227964793-560506b2-d55d-49af-91b8-ce9130149477.png)
 
-**socket:** wird als Eingang eines Funktionsblocks hinzugefügt und innerhalb der Schnittstelle des Funktionsblocks dargestellt.  
-**plug:** wird als Ausgang eines Funktionsblocks hinzugefügt und innerhalb der Schnittstelle des Funktionsblocks dargestellt.
 
-**Time: In Sekunden die der Baustein das Event sperrt**
+### **Interne Komponenten**
+- `DLY` (E_DELAY): Kernkomponente für die Zeitsteuerung
 
-Der **E\_TimeOut** ist ein zusammengesetzter Funktionsblock. Innerhalb des Netzwerks eines zusammengesetzten Funktionsblocks wird jeder Adapter, der zu seiner Schnittstelle hinzugefügt wird, durch einen Adapterblock repräsentiert, der wie ein Funktionsblock aussieht. Die Schnittstellenelemente dieses Adapterblocks sind wie ein Funktionsblock verbunden.
+## Funktionsweise
+
+1. **Timeout-Initialisierung**:
+   - Bei `START`-Ereignis am Socket beginnt der Timer
+   - Verwendet den konfigurierten `DT`-Wert
+
+2. **Timeout-Operation**:
+   - Timer läuft für die spezifizierte `DT`-Dauer
+   - Keine Reset-Funktion (im Gegensatz zu E_RDELAY)
+
+3. **Timeout-Abbruch**:
+   - `STOP`-Ereignis bricht aktiven Timer ab
+
+4. **Timeout-Auslösung**:
+   - Nach Ablauf von `DT` wird `TimeOut`-Ereignis generiert
+   - Signalisiert über den Adapter-Socket
+
+## Technische Besonderheiten
+
+✔ **Adapter-basierte** Schnittstelle  
+✔ **Einfache Timeout-Logik**  
+✔ **Deterministisches** Zeitverhalten  
+✔ **Echtzeitfähige** Implementierung  
+
+## Anwendungsszenarien
+
+- **Netzwerkkommunikation**: Antwort-Timeout-Überwachung
+- **Gerätesteuerung**: Watchdog-Funktionen
+- **Prozessüberwachung**: Zeitbegrenzte Operationen
+- **Sicherheitssysteme**: Notfall-Timeout
+
+## Vergleich mit E_RDELAY
+
+| Feature        | E_TimeOut | E_RDELAY |
+|---------------|-----------|----------|
+| Reset-Funktion | ❌        | ✔️       |
+| Adaptertyp    | ATimeOut  | ARTimeOut |
+| Komplexität   | Einfach   | Erweitert |
+
+## Fazit
+
+Der E_TimeOut-Baustein bietet eine robuste Grundimplementierung für Timeout-Anforderungen:
+
+- Einfache und zuverlässige Zeitüberwachung
+- Standardisierte Adapter-Schnittstelle
+- Klare Funktionsweise ohne Reset-Komplexität
+
+Durch die Verwendung des bewährten E_DELAY-Bausteins im Kern gewährleistet er präzise Zeitsteuerung für grundlegende Automatisierungsaufgaben. Die IEC 61499-Konformität ermöglicht einfache Integration in verteilte Steuerungssysteme.


### PR DESCRIPTION
ARTimeOut.md

ATimeOut.md

set headlines differently for ATimeOut and ARTimeOut

E_CTD.md

E_CTUD_UDINT.md

E_CTUD.md

E_CYCLE.md

E_D_FF.md

E_DELAY.md

E_DEMUX.md

E_F_TRIG.md

remove Implementation example part

E_TABLE.md

E_MERGE.md

E_N_TABLE.md

E_R_TRIG.md

E_RDELAY.md

E_RESTART.md

update pictures for E_R_TRIG, E_RDELAY

E_SELECT.md

E_RTimeOut.md

edit E_RESTART

E_SPLIT.md

E_TABLE_CTRL.md

edit E_TABLE

E_TimeOut.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded and restructured technical documentation for multiple IEC 61499 event blocks and adapters, including detailed introductions, interface descriptions, functional behavior, technical features, application scenarios, and comparison tables.
  - Improved clarity, structure, and completeness with diagrams, tables, and practical examples for blocks such as ATimeOut, ARTimeOut, E_CTD, E_CTUD, E_CYCLE, E_DELAY, E_DEMUX, E_D_FF, E_F_TRIG, E_MERGE, E_N_TABLE, E_RDELAY, E_RESTART, E_RTimeOut, E_R_TRIG, E_SELECT, E_SPLIT, E_TABLE, E_TABLE_CTRL, and E_TimeOut.
  - No changes to code or public interfaces; updates are limited to documentation content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->