### PR TITLE
hsv2rgb and strip_set_pixel

### DIFF
--- a/docs/typelibrary/esp-addons/hsv2rgb.md
+++ b/docs/typelibrary/esp-addons/hsv2rgb.md
@@ -1,3 +1,71 @@
-### hsv2rgb
+# hsv2rgb
 
 ![hsv2rgb](https://user-images.githubusercontent.com/116869307/214141778-56fe9e06-d507-4cbd-a0c0-717217a4db83.png)
+
+* * * * * * * * * *
+
+## Einleitung
+Der **HSV2RGB** ist ein spezialisierter Funktionsbaustein nach IEC 61499-2 zur Konvertierung von HSV- in RGB-Farbwerte. Entwickelt unter EPL-2.0 Lizenz ermöglicht Version 1.0 die farbtreue Umrechnung für Visualisierungsanwendungen.
+
+## Schnittstellenstruktur
+
+### **Ereignis-Eingänge**
+- `REQ`: Konvertierungsanforderung (mit HSV-Werten)
+
+### **Ereignis-Ausgänge**
+- `CNF`: Konvertierungsbestätigung (mit RGB-Werten)
+
+### **Daten-Eingänge**
+- `hue` (UDINT): Farbton (0-360°)
+- `saturation` (UDINT): Sättigung (0-100%)
+- `value` (UDINT): Helligkeit (0-100%)
+
+### **Daten-Ausgänge**
+- `r` (UDINT): Rot-Anteil (0-255)
+- `g` (UDINT): Grün-Anteil (0-255)
+- `b` (UDINT): Blau-Anteil (0-255)
+
+## Funktionsprinzip
+
+1. **Anforderung**:
+   - `REQ`-Ereignis mit HSV-Parametern startet Konvertierung
+
+2. **Berechnung**:
+   - Implementiert standardisierten HSV→RGB-Algorithmus
+   - Berücksichtigt zylindrischen HSV-Farbraum
+
+3. **Ausgabe**:
+   - `CNF`-Ereignis mit berechneten RGB-Werten
+   - Wertebereich für RGB: 0-255 (24-bit Farbe)
+
+## Technische Besonderheiten
+
+✔ **Präzise Farbraumtransformation**  
+✔ **Integer-basierte Berechnung** (UDINT)  
+✔ **Echtzeitfähige** Konvertierung  
+✔ **Standardkonform** nach IEC 61499-2  
+
+## Anwendungsszenarien
+
+- **Visualisierungssysteme**: HMI-Farbdarstellung
+- **Landtechnik**: Statusanzeigen
+- **Bildverarbeitung**: Farbkorrekturen
+- **LED-Steuerungen**: Dynamische Beleuchtung
+
+## Vergleich mit ähnlichen Bausteinen
+
+| Feature        | HSV2RGB | RGB2HSV | GRAYSCALE |
+|---------------|---------|---------|-----------|
+| Konvertierung | HSV→RGB | RGB→HSV | RGB→Grau  |
+| Farbtiefe     | 24-bit  | 24-bit  | 8-bit     |
+| Parameter     | 3 Eing. | 3 Eing. | 3 Eing.   |
+
+## Fazit
+
+Der HSV2RGB-Baustein bietet eine professionelle Lösung für Farbraumkonvertierungen:
+
+- Intuitive HSV-Eingabe (Farbton/Sättigung/Helligkeit)
+- Standardisierte RGB-Ausgabe
+- Optimierte Performance für Echtzeitsysteme
+
+Besonders wertvoll für Anwendungen, die benutzerfreundliche Farbauswahl mit präziser RGB-Darstellung kombinieren müssen. Die IEC 61499-2-Konformität ermöglicht einfache Integration in industrielle Steuerungssysteme.

--- a/docs/typelibrary/esp-addons/strip_set_pixel.md
+++ b/docs/typelibrary/esp-addons/strip_set_pixel.md
@@ -1,3 +1,76 @@
-### strip_set_pixel
+# strip_set_pixel
 
 ![strip_set_pixel](https://user-images.githubusercontent.com/116869307/214141844-ddb96db7-341d-496e-b4cb-f277d1f6fb39.png)
+
+* * * * * * * * * *
+
+## Einleitung
+Der **STRIP_SET_PIXEL** ist ein spezialisierter Service-Interface-Baustein nach IEC 61499-2 zur Ansteuerung von LED-Streifen. Entwickelt unter EPL-2.0 Lizenz ermöglicht Version 1.0 die individuelle Ansteuerung einzelner LEDs in RGB-Streifen.
+
+## Schnittstellenstruktur
+
+### **Ereignis-Eingänge**
+- `INIT`: Initialisierung des LED-Controllers
+- `set_pixel`: Setzt Farbe für einzelne LED (mit Index und RGB-Werten)
+- `clear`: Löscht den gesamten LED-Streifen
+
+### **Ereignis-Ausgänge**
+- `INITO`: Bestätigung der Initialisierung
+- `set_pixel_CNF`: Bestätigung der Pixel-Setzung
+- `clear_CNF`: Bestätigung des Löschvorgangs
+
+#### **Daten-Eingänge**
+- `index` (UDINT): LED-Position im Streifen
+- `red` (UDINT): Rotwert (0-255)
+- `green` (UDINT): Grünwert (0-255)
+- `blue` (UDINT): Blauwert (0-255)
+
+#### **Daten-Ausgänge**
+- `set_pixel_return` (DINT): Fehlercode der Pixeloperation
+- `clear_return` (DINT): Fehlercode des Löschvorgangs
+
+## Funktionsweise
+
+1. **Initialisierung**:
+   - `INIT` startet den LED-Controller
+   - `INITO` bestätigt erfolgreichen Start
+
+2. **Pixelsteuerung**:
+   - `set_pixel` mit Index und RGB-Werten
+   - `set_pixel_CNF` mit Rückgabecode
+
+3. **Streifenreset**:
+   - `clear` deaktiviert alle LEDs
+   - `clear_CNF` bestätigt Operation
+
+## Technische Besonderheiten
+
+✔ **Individuelle LED-Ansteuerung**  
+✔ **24-bit RGB-Farbtiefe** pro LED  
+✔ **Fehlerrückmeldung** für alle Operationen  
+✔ **Echtzeitfähige** Steuerung  
+
+## Anwendungsszenarien
+
+- **Industrielle Beleuchtung**: Statusanzeigen
+- **Landmaschinen**: Arbeitszustandsvisualisierung
+- **Werbetechnik**: Dynamische Lichteffekte
+- **Architekturbeleuchtung**: Gebäudeillumination
+
+## Befehlstabelle
+
+| Befehl         | Parameter               | Rückgabewert          |
+|----------------|-------------------------|-----------------------|
+| INIT           | -                       | INITO                 |
+| set_pixel      | index, red, green, blue | set_pixel_return      |
+| clear          | -                       | clear_return          |
+
+## Fazit
+
+Der STRIP_SET_PIXEL-Baustein bietet eine professionelle Schnittstelle für LED-Streifen:
+
+- Präzise Einzel-LED-Steuerung
+- Volle RGB-Farbkontrolle
+- Robuste Fehlerrückmeldung
+
+Besonders geeignet für industrielle Anwendungen, die zuverlässige und flexible LED-Visualisierung erfordern. Die standardkonforme IEC 61499-2-Implementierung ermöglicht einfache Integration in Automatisierungssysteme.


### PR DESCRIPTION
pages for 
hsv2rgb
strip_set_pixel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded and restructured documentation for the HSV to RGB converter, providing detailed interface descriptions, functional principles, technical features, application scenarios, and comparison with related modules.
  - Enhanced documentation for the RGB LED strip control module, including comprehensive interface details, workflow explanations, technical highlights, application examples, and command summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->