### PR TITLE
Enhances type compatibility docs with casting guidelines

### DIFF
--- a/docs/Allgemeines/Datentypen/Typkompatibilität.md
+++ b/docs/Allgemeines/Datentypen/Typkompatibilität.md
@@ -133,7 +133,7 @@ UDINT#16777216  →  UDINT_TO_LREAL()  →  LREAL#16777216.0  ✓
 ```
 
 Dies betrifft insbesondere:
-- UDINT (32 Bit) und DWORD (32 Bit) Umwandlungen in REAL
-- LWORD (64 Bit) und ULINT (64 Bit) Umwandlungen in LREAL (bei LREAL tritt der Präzisionsverlust erst ab 2^53 auf)
+- UDINT (32 Bit) Umwandlungen in REAL (oder DWORD nach Umwandlung in UDINT)
+- ULINT (64 Bit) Umwandlungen in LREAL (oder LWORD nach Umwandlung in ULINT; bei LREAL tritt der Präzisionsverlust erst ab 2^53 auf)
 
 **Faustregel:** Alle FIELDBUS Signal-Bausteine für DWORD, UDINT, LWORD und ULINT sollten `LREAL` als Ausgabetyp verwenden.

--- a/docs/Allgemeines/Datentypen/Typkompatibilität.md
+++ b/docs/Allgemeines/Datentypen/Typkompatibilität.md
@@ -122,8 +122,8 @@ REAL hat nur 32 Bit und kann daher nur **7 Dezimalstellen** präzise darstellen.
 Bei der Konvertierung von großen vorzeichenlosen Werten geht ab **16.777.216** (2^24) die Genauigkeit verloren:
 
 ```
-UDINT#16777216  →  REAL#16777216.0  →  Fehler!
-UDINT#16777217  →  REAL#16777216.0  →  Gleicher Wert!
+UDINT#16777216  →  REAL#16777216.0  →  Korrekt (2^24)
+UDINT#16777217  →  REAL#16777216.0  →  Präzisionsverlust (Rundung)
 ```
 
 **Lösung:** Bei Werten ≥ 16.777.216 `LREAL` statt `REAL` verwenden:

--- a/docs/Allgemeines/Datentypen/Typkompatibilität.md
+++ b/docs/Allgemeines/Datentypen/Typkompatibilität.md
@@ -103,11 +103,11 @@ Stattdessen müssen Sie über den passenden vorzeichenlosen Integer-Typen konver
 | BYTE | REAL | `BYTE` → `USINT` → `REAL` |
 | WORD | REAL | `WORD` → `UINT` → `REAL` |
 | DWORD | REAL | `DWORD` → `UDINT` → `REAL` |
-| LWORD | REAL/LREAL | `LWORD` → `ULINT` → `LREAL` |
+| LWORD | LREAL | `LWORD` → `ULINT` → `LREAL` |
 
-### DWORD_TO_REAL = reinterpret_cast
+### DWORD_TO_REAL, LWORD_TO_LREAL = reinterpret_cast
 
-**Wichtig:** `DWORD_TO_REAL` in 4diac entspricht einem `reinterpret_cast` in C++. Das bedeutet:
+**Wichtig:** `DWORD_TO_REAL` und `LWORD_TO_LREAL` in 4diac entsprechen einem `reinterpret_cast` in C++. Das bedeutet:
 
 - Die Bit-Darstellung wird direkt als REAL interpretiert
 - Es findet **keine numerische Umwandlung** statt

--- a/docs/Allgemeines/Datentypen/Typkompatibilität.md
+++ b/docs/Allgemeines/Datentypen/Typkompatibilität.md
@@ -86,3 +86,54 @@ Lang-Typen akzeptieren auch die kurzen Varianten:
 2. **Keine Verengung:** Ein größerer Typ darf nicht auf einen kleineren Typ verbunden werden (z. B. `UDINT` → `UINT` ist verboten).
 3. **Sign-Grenze:** Signed und Unsigned Integer sind nicht kompatibel (z. B. `INT` → `UINT` ist verboten).
 4. **Bool-Sonderregel:** `BOOL` darf auf jeden Bit-Typ (`BYTE`, `WORD`, `DWORD`, `LWORD`) verbunden werden.
+
+## Typ-Umwandlungen (Casting)
+
+### direkte Bit-String zu Gleitkomma Konvertierungen
+
+In IEC 61131-3 / IEC 61499 sind folgende implizite Konvertierungen **nicht definiert**:
+
+- `BYTE_TO_REAL` → **nicht definiert**
+- `WORD_TO_REAL` → **nicht definiert**
+
+Stattdessen müssen Sie über den passenden vorzeichenlosen Integer-Typen konvertieren:
+
+| Quelle | Ziel | Korrekte Umwandlung |
+|--------|------|---------------------|
+| BYTE | REAL | `BYTE` → `USINT` → `REAL` |
+| WORD | REAL | `WORD` → `UINT` → `REAL` |
+| DWORD | REAL | `DWORD` → `UDINT` → `REAL` |
+| LWORD | REAL/LREAL | `LWORD` → `ULINT` → `LREAL` |
+
+### DWORD_TO_REAL = reinterpret_cast
+
+**Wichtig:** `DWORD_TO_REAL` in 4diac entspricht einem `reinterpret_cast` in C++. Das bedeutet:
+
+- Die Bit-Darstellung wird direkt als REAL interpretiert
+- Es findet **keine numerische Umwandlung** statt
+- Beispiel: `16#41480000` als DWORD wird zu `12.5` als REAL (gleiche Bitrepräsentation)
+
+Dies ist in der Regel **nicht** das gewünschte Verhalten für numerische Umwandlungen!
+
+### Das 16.777.216 Problem (REAL Präzisionsverlust)
+
+REAL hat nur 32 Bit und kann daher nur **7 Dezimalstellen** präzise darstellen.
+
+Bei der Konvertierung von großen vorzeichenlosen Werten geht ab **16.777.216** (2^24) die Genauigkeit verloren:
+
+```
+UDINT#16777216  →  REAL#16777216.0  →  Fehler!
+UDINT#16777217  →  REAL#16777216.0  →  Gleicher Wert!
+```
+
+**Lösung:** Bei Werten ≥ 16.777.216 `LREAL` statt `REAL` verwenden:
+
+```
+UDINT#16777216  →  UDINT_TO_LREAL()  →  LREAL#16777216.0  ✓
+```
+
+Dies betrifft insbesondere:
+- UDINT (32 Bit) und DWORD (32 Bit) Umwandlungen
+- LWORD (64 Bit) und ULINT (64 Bit) Umwandlungen
+
+**Faustregel:** Alle FIELDBUS Signal-Bausteine für DWORD, UDINT, LWORD und ULINT sollten `LREAL` als Ausgabetyp verwenden.

--- a/docs/Allgemeines/Datentypen/Typkompatibilität.md
+++ b/docs/Allgemeines/Datentypen/Typkompatibilität.md
@@ -91,7 +91,7 @@ Lang-Typen akzeptieren auch die kurzen Varianten:
 
 ### Direkte Bit-String-zu-Gleitkomma-Konvertierungen
 
-In IEC 61131-3 / IEC 61499 sind folgende implizite Konvertierungen **nicht definiert**:
+In IEC 61131-3 / IEC 61499 sind folgende direkten Konvertierungen **nicht definiert**:
 
 - `BYTE_TO_REAL` → **nicht definiert**
 - `WORD_TO_REAL` → **nicht definiert**

--- a/docs/Allgemeines/Datentypen/Typkompatibilität.md
+++ b/docs/Allgemeines/Datentypen/Typkompatibilität.md
@@ -89,7 +89,7 @@ Lang-Typen akzeptieren auch die kurzen Varianten:
 
 ## Typ-Umwandlungen (Casting)
 
-### direkte Bit-String zu Gleitkomma Konvertierungen
+### Direkte Bit-String-zu-Gleitkomma-Konvertierungen
 
 In IEC 61131-3 / IEC 61499 sind folgende implizite Konvertierungen **nicht definiert**:
 

--- a/docs/Allgemeines/Datentypen/Typkompatibilität.md
+++ b/docs/Allgemeines/Datentypen/Typkompatibilität.md
@@ -133,7 +133,7 @@ UDINT#16777216  →  UDINT_TO_LREAL()  →  LREAL#16777216.0  ✓
 ```
 
 Dies betrifft insbesondere:
-- UDINT (32 Bit) und DWORD (32 Bit) Umwandlungen
-- LWORD (64 Bit) und ULINT (64 Bit) Umwandlungen
+- UDINT (32 Bit) und DWORD (32 Bit) Umwandlungen in REAL
+- LWORD (64 Bit) und ULINT (64 Bit) Umwandlungen in REAL (bei LREAL tritt der Präzisionsverlust erst ab 2^53 auf)
 
 **Faustregel:** Alle FIELDBUS Signal-Bausteine für DWORD, UDINT, LWORD und ULINT sollten `LREAL` als Ausgabetyp verwenden.

--- a/docs/Allgemeines/Datentypen/Typkompatibilität.md
+++ b/docs/Allgemeines/Datentypen/Typkompatibilität.md
@@ -122,8 +122,8 @@ REAL hat nur 32 Bit und kann daher nur **7 Dezimalstellen** präzise darstellen.
 Bei der Konvertierung von großen vorzeichenlosen Werten geht ab **16.777.216** (2^24) die Genauigkeit verloren:
 
 ```iecst
-UDINT#16777216  →  REAL#16777216.0  →  Korrekt (2^24)
-UDINT#16777217  →  REAL#16777216.0  →  Präzisionsverlust (Rundung)
+UDINT#16777216  →  UDINT_TO_REAL()  →  REAL#16777216.0  →  Korrekt (2^24)
+UDINT#16777217  →  UDINT_TO_REAL()  →  REAL#16777216.0  →  Präzisionsverlust (Rundung)
 ```
 
 **Lösung:** Bei Werten ≥ 16.777.216 `LREAL` statt `REAL` verwenden:

--- a/docs/Allgemeines/Datentypen/Typkompatibilität.md
+++ b/docs/Allgemeines/Datentypen/Typkompatibilität.md
@@ -134,6 +134,6 @@ UDINT#16777216  →  UDINT_TO_LREAL()  →  LREAL#16777216.0  ✓
 
 Dies betrifft insbesondere:
 - UDINT (32 Bit) und DWORD (32 Bit) Umwandlungen in REAL
-- LWORD (64 Bit) und ULINT (64 Bit) Umwandlungen in REAL (bei LREAL tritt der Präzisionsverlust erst ab 2^53 auf)
+- LWORD (64 Bit) und ULINT (64 Bit) Umwandlungen in LREAL (bei LREAL tritt der Präzisionsverlust erst ab 2^53 auf)
 
 **Faustregel:** Alle FIELDBUS Signal-Bausteine für DWORD, UDINT, LWORD und ULINT sollten `LREAL` als Ausgabetyp verwenden.

--- a/docs/Allgemeines/Datentypen/Typkompatibilität.md
+++ b/docs/Allgemeines/Datentypen/Typkompatibilität.md
@@ -129,7 +129,7 @@ UDINT#16777217  →  UDINT_TO_REAL()  →  REAL#16777216.0  →  Präzisionsverl
 **Lösung:** Bei Werten ≥ 16.777.216 `LREAL` statt `REAL` verwenden:
 
 ```iecst
-UDINT#16777216  →  UDINT_TO_LREAL()  →  LREAL#16777216.0  ✓
+UDINT#16777217  →  UDINT_TO_LREAL()  →  LREAL#16777217.0  ✓
 ```
 
 Dies betrifft insbesondere:

--- a/docs/Allgemeines/Datentypen/Typkompatibilität.md
+++ b/docs/Allgemeines/Datentypen/Typkompatibilität.md
@@ -121,14 +121,14 @@ REAL hat nur 32 Bit und kann daher nur **7 Dezimalstellen** präzise darstellen.
 
 Bei der Konvertierung von großen vorzeichenlosen Werten geht ab **16.777.216** (2^24) die Genauigkeit verloren:
 
-```
+```iecst
 UDINT#16777216  →  REAL#16777216.0  →  Korrekt (2^24)
 UDINT#16777217  →  REAL#16777216.0  →  Präzisionsverlust (Rundung)
 ```
 
 **Lösung:** Bei Werten ≥ 16.777.216 `LREAL` statt `REAL` verwenden:
 
-```
+```iecst
 UDINT#16777216  →  UDINT_TO_LREAL()  →  LREAL#16777216.0  ✓
 ```
 


### PR DESCRIPTION
Extends the documentation on type compatibility to include detailed guidelines for type conversions, focusing on mitigating precision loss and clarifying the use of `reinterpret_cast` in 4diac.

- Introduces new section on casting practices with examples of indirect conversions avoiding precision errors.
- Highlights the reinterpretation process for specific DWORD and LWORD conversions, relating to 4diac behavior.
- Advises on using `LREAL` for maintaining accuracy in larger data types.

Addresses conversions that previously caused precision issues and adds explicit instructions to avoid common pitfalls.

## Summary by Sourcery

Documentation:
- Document casting practices and type conversions to avoid precision loss and clarify DWORD/LWORD reinterpretation and the use of LREAL for accuracy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced type conversion and casting guidance for IEC 61131-3/IEC 61499 standards
  * Added precision loss recommendations and best practices for floating-point operations
  * Clarified bit reinterpretation behavior and guidance for Fieldbus signal implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->