### PR TITLE
feat: add global nav collapse/expand toggle button

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -9,3 +9,46 @@
 #rtd-stickybox-container {
   text-align: center;
 }
+
+/* Nav toggle button */
+.nav-toggle-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  margin-bottom: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--md-default-fg-color);
+  background: var(--md-default-bg-color);
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.2rem;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.nav-toggle-btn:hover {
+  background: var(--md-default-fg-color--lightest);
+  border-color: var(--md-default-fg-color--lighter);
+}
+
+.nav-toggle-btn .md-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.nav-toggle-btn .nav-toggle-label {
+  flex: 1;
+  text-align: left;
+}
+
+/* Collapsed state: hide nested lists */
+[data-nav-collapsed="true"] .md-nav__item--nested > .md-nav__list {
+  display: none !important;
+}
+
+/* Collapsed state: rotate chevrons */
+[data-nav-collapsed="true"] .md-nav__item--nested > .md-nav__link .md-nav__icon {
+  transform: rotate(-90deg);
+}

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -43,12 +43,4 @@
   text-align: left;
 }
 
-/* Collapsed state: hide nested lists */
-[data-nav-collapsed="true"] .md-nav__item--nested > .md-nav__list {
-  display: none !important;
-}
-
-/* Collapsed state: rotate chevrons */
-[data-nav-collapsed="true"] .md-nav__item--nested > .md-nav__link .md-nav__icon {
-  transform: rotate(-90deg);
-}
+/* Collapsed state handled by .md-toggle checkbox state — no custom CSS needed */

--- a/docs/_static/js/nav-toggle.js
+++ b/docs/_static/js/nav-toggle.js
@@ -3,8 +3,8 @@
   'use strict';
 
   const STORAGE_KEY = 'nav-toggle-collapsed';
-  const ICON_EXPAND = 'material/unfold-more';
-  const ICON_COLLAPSE = 'material/unfold-less';
+  const SVG_EXPAND = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" style="vertical-align: middle;"><path d="M12 18.17L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15M12 5.83L15.17 9l1.41-1.41L12 3 7.41 7.41 8.83 9 12 5.83z"/></svg>';
+  const SVG_COLLAPSE = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" style="vertical-align: middle;"><path d="M12 8L16.59 12.59 18 11.17 12 5.17 6 11.17 7.41 12.59 12 8zm0 8l-4.59-4.59L6 12.83l6 6 6-6-1.41-1.42L12 16z"/></svg>';
   const LABEL_EXPAND = 'Alle ausklappen';
   const LABEL_COLLAPSE = 'Alle einklappen';
 
@@ -14,7 +14,11 @@
 
   function setCollapsed(collapsed) {
     document.body.setAttribute('data-nav-collapsed', String(collapsed));
-    sessionStorage.setItem(STORAGE_KEY, String(collapsed));
+    try {
+      sessionStorage.setItem(STORAGE_KEY, String(collapsed));
+    } catch (e) {
+      // Ignore storage errors
+    }
     updateButton();
   }
 
@@ -24,12 +28,8 @@
 
     navItems.forEach(function (item) {
       const toggle = item.querySelector('.md-toggle');
-      const list = item.querySelector('.md-nav__list');
       if (toggle) {
         toggle.checked = !collapsed;
-      }
-      if (list) {
-        list.style.display = collapsed ? 'none' : '';
       }
     });
 
@@ -44,11 +44,13 @@
     const label = btn.querySelector('.nav-toggle-label');
 
     if (icon) {
-      icon.textContent = collapsed ? ':' + ICON_EXPAND + ':' : ':' + ICON_COLLAPSE + ':';
+      icon.innerHTML = collapsed ? SVG_EXPAND : SVG_COLLAPSE;
     }
     if (label) {
       label.textContent = collapsed ? LABEL_EXPAND : LABEL_COLLAPSE;
     }
+    btn.setAttribute('aria-pressed', String(!collapsed));
+    btn.setAttribute('aria-expanded', String(!collapsed));
   }
 
   function createButton() {
@@ -60,26 +62,32 @@
     btn.className = 'md-button nav-toggle-btn';
     btn.type = 'button';
     btn.innerHTML =
-      '<span class="md-icon">:' + ICON_COLLAPSE + ':</span>' +
+      '<span class="md-icon">' + SVG_COLLAPSE + '</span>' +
       '<span class="nav-toggle-label">' + LABEL_COLLAPSE + '</span>';
+
+    const collapsed = isCollapsed();
+    btn.setAttribute('aria-pressed', String(!collapsed));
+    btn.setAttribute('aria-expanded', String(!collapsed));
     btn.addEventListener('click', toggleNav);
 
     sidebar.insertBefore(btn, sidebar.firstChild);
   }
 
   function init() {
-    const stored = sessionStorage.getItem(STORAGE_KEY);
-    const collapsed = stored === 'true';
+    let collapsed = false;
+    try {
+      const stored = sessionStorage.getItem(STORAGE_KEY);
+      collapsed = stored === 'true';
+    } catch (e) {
+      // Ignore storage errors
+    }
     document.body.setAttribute('data-nav-collapsed', String(collapsed));
     createButton();
     if (collapsed) {
-      // Apply collapsed state without toggling storage again
       const navItems = document.querySelectorAll('.md-nav__item--nested');
       navItems.forEach(function (item) {
         const toggle = item.querySelector('.md-toggle');
-        const list = item.querySelector('.md-nav__list');
         if (toggle) toggle.checked = false;
-        if (list) list.style.display = 'none';
       });
       updateButton();
     }

--- a/docs/_static/js/nav-toggle.js
+++ b/docs/_static/js/nav-toggle.js
@@ -1,0 +1,93 @@
+// nav-toggle.js — Global navigation collapse/expand toggle for MkDocs Material
+(function () {
+  'use strict';
+
+  const STORAGE_KEY = 'nav-toggle-collapsed';
+  const ICON_EXPAND = 'material/unfold-more';
+  const ICON_COLLAPSE = 'material/unfold-less';
+  const LABEL_EXPAND = 'Alle ausklappen';
+  const LABEL_COLLAPSE = 'Alle einklappen';
+
+  function isCollapsed() {
+    return document.body.getAttribute('data-nav-collapsed') === 'true';
+  }
+
+  function setCollapsed(collapsed) {
+    document.body.setAttribute('data-nav-collapsed', String(collapsed));
+    sessionStorage.setItem(STORAGE_KEY, String(collapsed));
+    updateButton();
+  }
+
+  function toggleNav() {
+    const collapsed = !isCollapsed();
+    const navItems = document.querySelectorAll('.md-nav__item--nested');
+
+    navItems.forEach(function (item) {
+      const toggle = item.querySelector('.md-toggle');
+      const list = item.querySelector('.md-nav__list');
+      if (toggle) {
+        toggle.checked = !collapsed;
+      }
+      if (list) {
+        list.style.display = collapsed ? 'none' : '';
+      }
+    });
+
+    setCollapsed(collapsed);
+  }
+
+  function updateButton() {
+    const btn = document.getElementById('nav-toggle-btn');
+    if (!btn) return;
+    const collapsed = isCollapsed();
+    const icon = btn.querySelector('.md-icon');
+    const label = btn.querySelector('.nav-toggle-label');
+
+    if (icon) {
+      icon.textContent = collapsed ? ':' + ICON_EXPAND + ':' : ':' + ICON_COLLAPSE + ':';
+    }
+    if (label) {
+      label.textContent = collapsed ? LABEL_EXPAND : LABEL_COLLAPSE;
+    }
+  }
+
+  function createButton() {
+    const sidebar = document.querySelector('.md-sidebar--primary .md-sidebar__inner');
+    if (!sidebar) return;
+
+    const btn = document.createElement('button');
+    btn.id = 'nav-toggle-btn';
+    btn.className = 'md-button nav-toggle-btn';
+    btn.type = 'button';
+    btn.innerHTML =
+      '<span class="md-icon">:' + ICON_COLLAPSE + ':</span>' +
+      '<span class="nav-toggle-label">' + LABEL_COLLAPSE + '</span>';
+    btn.addEventListener('click', toggleNav);
+
+    sidebar.insertBefore(btn, sidebar.firstChild);
+  }
+
+  function init() {
+    const stored = sessionStorage.getItem(STORAGE_KEY);
+    const collapsed = stored === 'true';
+    document.body.setAttribute('data-nav-collapsed', String(collapsed));
+    createButton();
+    if (collapsed) {
+      // Apply collapsed state without toggling storage again
+      const navItems = document.querySelectorAll('.md-nav__item--nested');
+      navItems.forEach(function (item) {
+        const toggle = item.querySelector('.md-toggle');
+        const list = item.querySelector('.md-nav__list');
+        if (toggle) toggle.checked = false;
+        if (list) list.style.display = 'none';
+      });
+      updateButton();
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,10 @@ theme:
 plugins:
 - search
 
+extra_javascript:
+- _static/js/expand_tabs.js
+- _static/js/nav-toggle.js
+
 markdown_extensions:
 - attr_list
 - md_in_html


### PR DESCRIPTION
Adds a button to the sidebar that toggles all navigation subsections between collapsed and expanded states. State is persisted across page navigations via sessionStorage.

rm superpowers dir

## Summary by Sourcery

Add a global toggle to collapse or expand all navigation subsections in the MkDocs Material sidebar and wire it into the docs theme.

New Features:
- Introduce a sidebar button that toggles all nested navigation items between collapsed and expanded states.
- Persist the global navigation collapsed/expanded state across page navigations using sessionStorage.

Enhancements:
- Style the global navigation toggle button and collapsed navigation state via custom CSS for the docs theme.

Documentation:
- Include the new navigation toggle JavaScript in the MkDocs configuration so it is loaded on documentation pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sidebar navigation toggle for the documentation, letting users collapse and expand nested navigation for a cleaner reading experience.
  * The collapsed/expanded preference is remembered for the session and applied on page load.
* **Enhancements**
  * Updated the navigation toggle button styling and hover behavior for improved clarity and alignment.
  * Enabled the required client-side scripts in the documentation build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->