### PR TITLE
fix: improve button visibility and target all sidebar toggles

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -10,20 +10,29 @@
   text-align: center;
 }
 
-/* Nav toggle button */
-.nav-toggle-btn {
+/* Nav toggle wrapper */
+.nav-toggle-wrapper {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  width: 100%;
+  margin-top: 0;
   margin-bottom: 0.5rem;
-  padding: 0.4rem 0.6rem;
-  font-size: 0.75rem;
-  font-weight: 500;
+  padding: 0;
+}
+
+/* Icon-only toggle button */
+.nav-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  flex-shrink: 0;
   color: var(--md-default-fg-color);
   background: var(--md-default-bg-color);
-  border: 1px solid var(--md-default-fg-color--lightest);
-  border-radius: 0.2rem;
+  border: 1.5px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.25rem;
   cursor: pointer;
   transition: background 0.2s, border-color 0.2s;
 }
@@ -34,13 +43,27 @@
 }
 
 .nav-toggle-btn .md-icon {
-  font-size: 1rem;
+  font-size: 1.1rem;
   line-height: 1;
+  display: flex;
+  align-items: center;
 }
 
-.nav-toggle-btn .nav-toggle-label {
-  flex: 1;
-  text-align: left;
+/* Label beside the button */
+.nav-toggle-label {
+  display: inline-flex;
+  align-items: center;
+  height: 2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--md-default-fg-color);
+  user-select: none;
+  cursor: default;
 }
 
-/* Collapsed state handled by .md-toggle checkbox state — no custom CSS needed */
+/* Collapsed state: collapse only the first sub-level under each section.
+   Deeper nesting is left visible. Material's checkbox CSS has higher
+   specificity, so individual section toggles still work. */
+[data-nav-collapsed="true"] .md-nav__item--section > .md-nav > .md-nav__list > .md-nav__item--nested > .md-nav > .md-nav__list {
+  display: none;
+}

--- a/docs/_static/js/nav-toggle.js
+++ b/docs/_static/js/nav-toggle.js
@@ -2,9 +2,8 @@
 (function () {
   'use strict';
 
-  const STORAGE_KEY = 'nav-toggle-collapsed';
-  const SVG_EXPAND = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" style="vertical-align: middle;"><path d="M12 18.17L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15M12 5.83L15.17 9l1.41-1.41L12 3 7.41 7.41 8.83 9 12 5.83z"/></svg>';
-  const SVG_COLLAPSE = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" style="vertical-align: middle;"><path d="M12 8L16.59 12.59 18 11.17 12 5.17 6 11.17 7.41 12.59 12 8zm0 8l-4.59-4.59L6 12.83l6 6 6-6-1.41-1.42L12 16z"/></svg>';
+  const SVG_EXPAND = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M12 18.17L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15M12 5.83L15.17 9l1.41-1.41L12 3 7.41 7.41 8.83 9 12 5.83z"/></svg>';
+  const SVG_COLLAPSE = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M12 8L16.59 12.59 18 11.17 12 5.17 6 11.17 7.41 12.59 12 8zm0 8l-4.59-4.59L6 12.83l6 6 6-6-1.41-1.42L12 16z"/></svg>';
   const LABEL_EXPAND = 'Alle ausklappen';
   const LABEL_COLLAPSE = 'Alle einklappen';
 
@@ -14,83 +13,69 @@
 
   function setCollapsed(collapsed) {
     document.body.setAttribute('data-nav-collapsed', String(collapsed));
-    try {
-      sessionStorage.setItem(STORAGE_KEY, String(collapsed));
-    } catch (e) {
-      // Ignore storage errors
-    }
-    updateButton();
+    updateWidget();
   }
 
   function toggleNav() {
     const collapsed = !isCollapsed();
-    const navItems = document.querySelectorAll('.md-nav__item--nested');
 
-    navItems.forEach(function (item) {
-      const toggle = item.querySelector('.md-toggle');
-      if (toggle) {
-        toggle.checked = !collapsed;
-      }
+    const toggles = document.querySelectorAll('.md-sidebar--primary .md-toggle');
+    toggles.forEach(function (toggle) {
+      toggle.checked = !collapsed;
+    });
+
+    const subLists = document.querySelectorAll(
+      '.md-sidebar--primary .md-nav__item--section > .md-nav > .md-nav__list > .md-nav__item--nested > .md-nav > .md-nav__list'
+    );
+    subLists.forEach(function (list) {
+      list.style.display = collapsed ? 'none' : '';
     });
 
     setCollapsed(collapsed);
   }
 
-  function updateButton() {
+  function updateWidget() {
     const btn = document.getElementById('nav-toggle-btn');
-    if (!btn) return;
+    const label = document.getElementById('nav-toggle-label');
+    if (!btn || !label) return;
     const collapsed = isCollapsed();
-    const icon = btn.querySelector('.md-icon');
-    const label = btn.querySelector('.nav-toggle-label');
 
-    if (icon) {
-      icon.innerHTML = collapsed ? SVG_EXPAND : SVG_COLLAPSE;
-    }
-    if (label) {
-      label.textContent = collapsed ? LABEL_EXPAND : LABEL_COLLAPSE;
-    }
+    btn.querySelector('.md-icon').innerHTML = collapsed ? SVG_EXPAND : SVG_COLLAPSE;
+    label.textContent = collapsed ? LABEL_EXPAND : LABEL_COLLAPSE;
     btn.setAttribute('aria-pressed', String(!collapsed));
     btn.setAttribute('aria-expanded', String(!collapsed));
   }
 
-  function createButton() {
+  function createWidget() {
     const sidebar = document.querySelector('.md-sidebar--primary .md-sidebar__inner');
     if (!sidebar) return;
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'nav-toggle-wrapper';
 
     const btn = document.createElement('button');
     btn.id = 'nav-toggle-btn';
     btn.className = 'md-button nav-toggle-btn';
     btn.type = 'button';
-    btn.innerHTML =
-      '<span class="md-icon">' + SVG_COLLAPSE + '</span>' +
-      '<span class="nav-toggle-label">' + LABEL_COLLAPSE + '</span>';
-
-    const collapsed = isCollapsed();
-    btn.setAttribute('aria-pressed', String(!collapsed));
-    btn.setAttribute('aria-expanded', String(!collapsed));
+    btn.setAttribute('aria-label', LABEL_COLLAPSE);
+    btn.setAttribute('aria-pressed', String(true));
+    btn.setAttribute('aria-expanded', String(true));
+    btn.innerHTML = '<span class="md-icon">' + SVG_COLLAPSE + '</span>';
     btn.addEventListener('click', toggleNav);
 
-    sidebar.insertBefore(btn, sidebar.firstChild);
+    const label = document.createElement('span');
+    label.id = 'nav-toggle-label';
+    label.className = 'nav-toggle-label';
+    label.textContent = LABEL_COLLAPSE;
+
+    wrapper.appendChild(btn);
+    wrapper.appendChild(label);
+    sidebar.insertBefore(wrapper, sidebar.firstChild);
   }
 
   function init() {
-    let collapsed = false;
-    try {
-      const stored = sessionStorage.getItem(STORAGE_KEY);
-      collapsed = stored === 'true';
-    } catch (e) {
-      // Ignore storage errors
-    }
-    document.body.setAttribute('data-nav-collapsed', String(collapsed));
-    createButton();
-    if (collapsed) {
-      const navItems = document.querySelectorAll('.md-nav__item--nested');
-      navItems.forEach(function (item) {
-        const toggle = item.querySelector('.md-toggle');
-        if (toggle) toggle.checked = false;
-      });
-      updateButton();
-    }
+    document.body.setAttribute('data-nav-collapsed', 'false');
+    createWidget();
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
Make button work correctly and only collapse until the correct depth

## Summary by Sourcery

Adjust documentation sidebar navigation toggle widget for improved visibility and controlled collapse behavior.

New Features:
- Introduce a dedicated nav toggle widget wrapper with a separate label element in the primary sidebar.
- Restrict global sidebar collapsing to the first nested sub-level while leaving deeper levels visible.

Enhancements:
- Increase nav toggle icon size and switch to an icon-only button with an adjacent textual label for better clarity and layout.
- Update nav toggle JavaScript to target only primary sidebar toggles and simplify initialization without session-based persistence.
- Refine nav toggle button styling, spacing, and border radius to better align with the documentation theme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Navigation toggle button redesigned to icon-only format with separate label display.
  * Updated navigation collapse and expand behavior for enhanced interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->